### PR TITLE
fix(pipeline): add startup env validation and clear boot log

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,12 +1,16 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import model_validator
+
+
+REQUIRED_VARS = ["supabase_url", "supabase_service_key", "anthropic_api_key"]
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
-    supabase_url: str
-    supabase_service_key: str
-    anthropic_api_key: str
+    supabase_url: str = ""
+    supabase_service_key: str = ""
+    anthropic_api_key: str = ""
     frontend_url: str = "http://localhost:3000"
 
     # Optional social platform keys
@@ -15,6 +19,17 @@ class Settings(BaseSettings):
     youtube_api_key: str = ""
     linkedin_client_id: str = ""
     linkedin_client_secret: str = ""
+
+    @model_validator(mode="after")
+    def check_required(self) -> "Settings":
+        missing = [var for var in REQUIRED_VARS if not getattr(self, var)]
+        if missing:
+            lines = "\n".join(f"  - {v.upper()}" for v in missing)
+            raise ValueError(
+                f"\n\n[SocialCraft AI] Missing required environment variables:\n{lines}\n\n"
+                "Add them to backend/.env and restart the server.\n"
+            )
+        return self
 
 
 settings = Settings()  # type: ignore[call-arg]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,13 +1,25 @@
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.routers import captions, users, publish, feedback, ml
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    print(f"\n  SocialCraft AI backend ready")
+    print(f"  Supabase : {settings.supabase_url}")
+    print(f"  Claude   : {'configured' if settings.anthropic_api_key else 'MISSING'}")
+    print(f"  CORS     : {settings.frontend_url}\n")
+    yield
+
+
 app = FastAPI(
     title="SocialCraft AI API",
     version="1.0.0",
     description="Multilingual social media caption generator with AI personalization",
+    lifespan=lifespan,
 )
 
 app.add_middleware(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,8 @@ python-dotenv==1.0.1
 pydantic==2.7.1
 pydantic-settings==2.3.0
 anthropic==0.28.0
-supabase==2.4.6
+supabase==2.28.3
+websockets>=11,<14
 scikit-learn==1.6.1
 pandas==2.2.3
 numpy==2.2.5


### PR DESCRIPTION
## Summary
- Validates all required env vars (`SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `ANTHROPIC_API_KEY`) on startup and exits with a clear error listing exactly what's missing — instead of starting and throwing a cryptic 500 on first request
- Adds a lifespan startup log showing Supabase URL, Claude status, and CORS origin so config is visible immediately on boot
- Locks `supabase==2.28.3` + `websockets<14` in requirements to support the new `sb_secret_...` key format

## Test plan
- [ ] Remove `ANTHROPIC_API_KEY` from `.env` → server should refuse to start with a clear message
- [ ] Add key back → server starts and prints boot summary
- [ ] `/health` returns `{"status": "ok"}`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)