### PR TITLE
feat(social): Facebook and Instagram publishing via Meta Graph API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 from app.config import settings
-from app.routers import captions, users, publish, feedback, ml, linkedin, analytics
+from app.routers import captions, users, publish, feedback, ml, linkedin, meta, analytics
 from app.services.scheduler_service import run_scheduler
 
 scheduler = AsyncIOScheduler()
@@ -18,6 +18,7 @@ async def lifespan(app: FastAPI):
     print(f"  Supabase : {settings.supabase_url}")
     print(f"  Claude   : {'configured' if settings.anthropic_api_key else 'MISSING'}")
     print(f"  LinkedIn : {'configured' if settings.linkedin_client_id else 'not set'}")
+    print(f"  Meta     : {'configured' if settings.meta_app_id else 'not set'}")
     print(f"  Scheduler: running (every 1 min)")
     print(f"  CORS     : {settings.frontend_url}\n")
     yield
@@ -45,6 +46,7 @@ app.include_router(publish.router,   prefix="/api/publish",   tags=["publish"])
 app.include_router(feedback.router,  prefix="/api/captions",  tags=["feedback"])
 app.include_router(ml.router,        prefix="/api/ml",        tags=["ml"])
 app.include_router(linkedin.router,  prefix="/api/linkedin",  tags=["linkedin"])
+app.include_router(meta.router,      prefix="/api/meta",      tags=["meta"])
 app.include_router(analytics.router, prefix="/api/analytics", tags=["analytics"])
 
 

--- a/backend/app/routers/meta.py
+++ b/backend/app/routers/meta.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+import logging
+import secrets
+import traceback
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+from app.config import settings
+from app.database import get_supabase
+from app.utils.auth import get_current_user_id
+from app.services import meta_service
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+REDIRECT_URI = "http://localhost:8000/api/meta/callback"
+
+
+@router.get("/connect")
+async def meta_connect(user_id: str = Depends(get_current_user_id)):
+    state = f"{user_id}.{secrets.token_urlsafe(8)}"
+    url = meta_service.get_authorization_url(REDIRECT_URI, state)
+    return {"success": True, "data": {"url": url}}
+
+
+@router.get("/callback")
+async def meta_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    error: str = Query(default=None),
+):
+    if error:
+        return RedirectResponse(
+            url=f"{settings.frontend_url}/dashboard/settings?meta=error&reason={error}"
+        )
+    try:
+        user_id = state.split(".")[0] if "." in state else None
+        if not user_id:
+            return RedirectResponse(
+                url=f"{settings.frontend_url}/dashboard/settings?meta=error&reason=invalid_state"
+            )
+
+        short = await meta_service.exchange_code_for_token(code, REDIRECT_URI)
+        long = await meta_service.get_long_lived_token(short["access_token"])
+        user_token = long["access_token"]
+        expires_at = meta_service.token_expires_at(long.get("expires_in", 5184000))
+
+        pages = await meta_service.get_user_pages(user_token)
+        if not pages:
+            return RedirectResponse(
+                url=f"{settings.frontend_url}/dashboard/settings?meta=error&reason=no_pages"
+            )
+
+        page = pages[0]
+        page_id = page["id"]
+        page_name = page["name"]
+        page_token = page["access_token"]  # page tokens don't expire
+
+        db = get_supabase()
+        db.table("oauth_tokens").upsert(
+            {
+                "user_id": user_id,
+                "platform": "facebook",
+                "access_token": page_token,
+                "expires_at": expires_at,
+                "platform_user_id": page_id,
+                "platform_username": page_name,
+            },
+            on_conflict="user_id,platform",
+        ).execute()
+
+        ig = await meta_service.get_instagram_account(page_id, page_token)
+        if ig:
+            db.table("oauth_tokens").upsert(
+                {
+                    "user_id": user_id,
+                    "platform": "instagram",
+                    "access_token": page_token,
+                    "expires_at": expires_at,
+                    "platform_user_id": ig["id"],
+                    "platform_username": ig.get("username", ""),
+                },
+                on_conflict="user_id,platform",
+            ).execute()
+
+        return RedirectResponse(
+            url=f"{settings.frontend_url}/dashboard/settings?meta=connected"
+        )
+    except Exception:
+        log.error("Meta callback failed:\n%s", traceback.format_exc())
+        return RedirectResponse(
+            url=f"{settings.frontend_url}/dashboard/settings?meta=error&reason=token_exchange_failed"
+        )
+
+
+@router.get("/status")
+async def meta_status(user_id: str = Depends(get_current_user_id)):
+    db = get_supabase()
+    result = (
+        db.table("oauth_tokens")
+        .select("platform, platform_username")
+        .eq("user_id", user_id)
+        .in_("platform", ["facebook", "instagram"])
+        .execute()
+    )
+    rows = {r["platform"]: r for r in (result.data or [])}
+    return {
+        "success": True,
+        "data": {
+            "facebook": {
+                "connected": "facebook" in rows,
+                "username": rows.get("facebook", {}).get("platform_username"),
+            },
+            "instagram": {
+                "connected": "instagram" in rows,
+                "username": rows.get("instagram", {}).get("platform_username"),
+            },
+        },
+    }
+
+
+@router.delete("/disconnect")
+async def meta_disconnect(user_id: str = Depends(get_current_user_id)):
+    db = get_supabase()
+    db.table("oauth_tokens").delete().eq("user_id", user_id).in_(
+        "platform", ["facebook", "instagram"]
+    ).execute()
+    return {"success": True}
+
+
+class FacebookPublishRequest(BaseModel):
+    caption_id: str
+    text: str
+
+
+class InstagramPublishRequest(BaseModel):
+    caption_id: str
+    text: str
+    image_url: str
+
+
+@router.post("/publish/facebook")
+async def publish_facebook(
+    req: FacebookPublishRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    db = get_supabase()
+    row = (
+        db.table("oauth_tokens")
+        .select("access_token, platform_user_id")
+        .eq("user_id", user_id)
+        .eq("platform", "facebook")
+        .execute()
+    ).data
+    if not row:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Facebook not connected.")
+    try:
+        result = await meta_service.publish_facebook_post(
+            page_id=row[0]["platform_user_id"],
+            page_access_token=row[0]["access_token"],
+            text=req.text,
+        )
+        db.table("captions").update({"was_used": True}).eq("id", req.caption_id).execute()
+        db.table("user_events").insert({
+            "user_id": user_id,
+            "event_type": "published",
+            "caption_id": req.caption_id,
+            "metadata": {"platform": "facebook"},
+        }).execute()
+        return {"success": True, "data": {"post_id": result.get("id", "")}}
+    except Exception as exc:
+        log.error("Facebook publish failed:\n%s", traceback.format_exc())
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"Facebook publish failed: {exc}")
+
+
+@router.post("/publish/instagram")
+async def publish_instagram(
+    req: InstagramPublishRequest,
+    user_id: str = Depends(get_current_user_id),
+):
+    db = get_supabase()
+    row = (
+        db.table("oauth_tokens")
+        .select("access_token, platform_user_id")
+        .eq("user_id", user_id)
+        .eq("platform", "instagram")
+        .execute()
+    ).data
+    if not row:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Instagram not connected.")
+    try:
+        result = await meta_service.publish_instagram_post(
+            ig_user_id=row[0]["platform_user_id"],
+            page_access_token=row[0]["access_token"],
+            image_url=req.image_url,
+            caption=req.text,
+        )
+        db.table("captions").update({"was_used": True}).eq("id", req.caption_id).execute()
+        db.table("user_events").insert({
+            "user_id": user_id,
+            "event_type": "published",
+            "caption_id": req.caption_id,
+            "metadata": {"platform": "instagram"},
+        }).execute()
+        return {"success": True, "data": {"post_id": result.get("id", "")}}
+    except Exception as exc:
+        log.error("Instagram publish failed:\n%s", traceback.format_exc())
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"Instagram publish failed: {exc}")

--- a/backend/app/routers/publish.py
+++ b/backend/app/routers/publish.py
@@ -13,6 +13,7 @@ class SchedulePostRequest(BaseModel):
     caption_id: str
     platform: str
     scheduled_at: datetime
+    image_url: str | None = None
 
 
 @router.post("/post", response_model=dict)
@@ -43,6 +44,7 @@ async def schedule_post(
         "scheduled_at": req.scheduled_at.isoformat(),
         "status": "pending",
         "created_at": datetime.utcnow().isoformat(),
+        **({"image_url": req.image_url} if req.image_url else {}),
     }
     db.table("scheduled_posts").insert(row).execute()
     return {"success": True, "data": row}

--- a/backend/app/services/meta_service.py
+++ b/backend/app/services/meta_service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+import httpx
+from datetime import datetime, timedelta
+from app.config import settings
+
+META_GRAPH_URL = "https://graph.facebook.com/v21.0"
+META_AUTH_URL = "https://www.facebook.com/v21.0/dialog/oauth"
+SCOPES = "pages_manage_posts,pages_read_engagement,instagram_basic,instagram_content_publish,pages_show_list"
+
+
+def get_authorization_url(redirect_uri: str, state: str) -> str:
+    return (
+        f"{META_AUTH_URL}"
+        f"?client_id={settings.meta_app_id}"
+        f"&redirect_uri={redirect_uri}"
+        f"&scope={SCOPES}"
+        f"&state={state}"
+        f"&response_type=code"
+    )
+
+
+async def exchange_code_for_token(code: str, redirect_uri: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{META_GRAPH_URL}/oauth/access_token",
+            params={
+                "client_id": settings.meta_app_id,
+                "client_secret": settings.meta_app_secret,
+                "redirect_uri": redirect_uri,
+                "code": code,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def get_long_lived_token(short_lived_token: str) -> dict:
+    """Exchange a short-lived user token for a 60-day long-lived token."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{META_GRAPH_URL}/oauth/access_token",
+            params={
+                "grant_type": "fb_exchange_token",
+                "client_id": settings.meta_app_id,
+                "client_secret": settings.meta_app_secret,
+                "fb_exchange_token": short_lived_token,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def get_user_pages(user_access_token: str) -> list[dict]:
+    """Return pages the user manages, each with its non-expiring page access token."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{META_GRAPH_URL}/me/accounts",
+            params={"fields": "id,name,access_token", "access_token": user_access_token},
+        )
+        resp.raise_for_status()
+        return resp.json().get("data", [])
+
+
+async def get_instagram_account(page_id: str, page_access_token: str) -> dict | None:
+    """Return the Instagram Business Account linked to a Facebook Page, or None."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{META_GRAPH_URL}/{page_id}",
+            params={
+                "fields": "instagram_business_account{id,username}",
+                "access_token": page_access_token,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json().get("instagram_business_account")
+
+
+async def publish_facebook_post(page_id: str, page_access_token: str, text: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{META_GRAPH_URL}/{page_id}/feed",
+            data={"message": text, "access_token": page_access_token},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def publish_instagram_post(
+    ig_user_id: str, page_access_token: str, image_url: str, caption: str
+) -> dict:
+    """Two-step Instagram publish: create media container then publish it."""
+    async with httpx.AsyncClient() as client:
+        container = await client.post(
+            f"{META_GRAPH_URL}/{ig_user_id}/media",
+            data={"image_url": image_url, "caption": caption, "access_token": page_access_token},
+        )
+        container.raise_for_status()
+        container_id = container.json()["id"]
+
+        publish = await client.post(
+            f"{META_GRAPH_URL}/{ig_user_id}/media_publish",
+            data={"creation_id": container_id, "access_token": page_access_token},
+        )
+        publish.raise_for_status()
+        return publish.json()
+
+
+def token_expires_at(expires_in: int) -> str:
+    return (datetime.utcnow() + timedelta(seconds=expires_in)).isoformat()

--- a/backend/app/services/scheduler_service.py
+++ b/backend/app/services/scheduler_service.py
@@ -3,9 +3,11 @@ import logging
 import uuid
 from datetime import datetime, timezone
 from app.database import get_supabase
-from app.services import linkedin_service
+from app.services import linkedin_service, meta_service
 
 log = logging.getLogger(__name__)
+
+_PLATFORMS = ("linkedin", "facebook", "instagram")
 
 
 async def run_scheduler() -> dict:
@@ -21,17 +23,19 @@ async def run_scheduler() -> dict:
         .execute()
     ).data or []
 
-    linkedin_user_ids = list({p["user_id"] for p in pending if p["platform"] == "linkedin"})
-    tokens_by_user: dict[str, dict] = {}
-    if linkedin_user_ids:
-        token_rows = (
-            db.table("oauth_tokens")
-            .select("user_id, access_token, platform_user_id")
-            .in_("user_id", linkedin_user_ids)
-            .eq("platform", "linkedin")
-            .execute()
-        ).data or []
-        tokens_by_user = {row["user_id"]: row for row in token_rows}
+    # Batch-fetch OAuth tokens for every platform that has pending posts
+    tokens: dict[str, dict[str, dict]] = {p: {} for p in _PLATFORMS}
+    for platform in _PLATFORMS:
+        user_ids = list({p["user_id"] for p in pending if p["platform"] == platform})
+        if user_ids:
+            rows = (
+                db.table("oauth_tokens")
+                .select("user_id, access_token, platform_user_id")
+                .in_("user_id", user_ids)
+                .eq("platform", platform)
+                .execute()
+            ).data or []
+            tokens[platform] = {row["user_id"]: row for row in rows}
 
     published, failed = 0, 0
 
@@ -45,16 +49,37 @@ async def run_scheduler() -> dict:
             if hashtags:
                 text += "\n\n" + " ".join(h if h.startswith("#") else f"#{h}" for h in hashtags)
 
+            token_row = tokens.get(platform, {}).get(user_id)
             post_id = None
-            if platform == "linkedin":
-                token_row = tokens_by_user.get(user_id)
-                if token_row:
-                    result = await linkedin_service.publish_text_post(
-                        access_token=token_row["access_token"],
-                        person_urn=token_row["platform_user_id"],
-                        text=text,
+
+            if platform == "linkedin" and token_row:
+                result = await linkedin_service.publish_text_post(
+                    access_token=token_row["access_token"],
+                    person_urn=token_row["platform_user_id"],
+                    text=text,
+                )
+                post_id = result.get("id")
+
+            elif platform == "facebook" and token_row:
+                result = await meta_service.publish_facebook_post(
+                    page_id=token_row["platform_user_id"],
+                    page_access_token=token_row["access_token"],
+                    text=text,
+                )
+                post_id = result.get("id")
+
+            elif platform == "instagram" and token_row:
+                image_url = post.get("image_url")
+                if image_url:
+                    result = await meta_service.publish_instagram_post(
+                        ig_user_id=token_row["platform_user_id"],
+                        page_access_token=token_row["access_token"],
+                        image_url=image_url,
+                        caption=text,
                     )
                     post_id = result.get("id")
+                else:
+                    log.warning("Skipping Instagram post %s — no image_url", post["id"])
 
             db.table("scheduled_posts").update({
                 "status": "published",

--- a/frontend/app/dashboard/scheduler/page.tsx
+++ b/frontend/app/dashboard/scheduler/page.tsx
@@ -3,37 +3,51 @@
 import { useState } from 'react'
 import {
   CalendarClock, Clock, CheckCircle2, XCircle,
-  Loader2, Plus, Linkedin, Globe,
+  Loader2, Plus, Linkedin, Globe, Facebook, Instagram,
 } from 'lucide-react'
 import { useScheduledPosts, useSchedulePost } from '@/hooks/useScheduler'
 import { useCaptionHistory } from '@/hooks/useCaption'
 import { useLinkedInStatus } from '@/hooks/useLinkedIn'
+import { useMetaStatus } from '@/hooks/useMeta'
 import { formatDate } from '@/lib/utils'
 import type { Platform } from '@/types'
 
 const PLATFORM_ICONS: Record<string, React.ReactNode> = {
-  linkedin: <Linkedin className="h-4 w-4 text-[#0A66C2]" />,
+  linkedin:  <Linkedin  className="h-4 w-4 text-[#0A66C2]" />,
+  facebook:  <Facebook  className="h-4 w-4 text-[#1877F2]" />,
+  instagram: <Instagram className="h-4 w-4 text-[#E1306C]" />,
 }
 
 const STATUS_CONFIG = {
-  pending:   { icon: Clock,         color: 'text-amber-600 bg-amber-50',  label: 'Pending' },
-  published: { icon: CheckCircle2,  color: 'text-green-600 bg-green-50',  label: 'Published' },
-  failed:    { icon: XCircle,       color: 'text-red-600 bg-red-50',      label: 'Failed' },
+  pending:   { icon: Clock,        color: 'text-amber-600 bg-amber-50', label: 'Pending' },
+  published: { icon: CheckCircle2, color: 'text-green-600 bg-green-50', label: 'Published' },
+  failed:    { icon: XCircle,      color: 'text-red-600 bg-red-50',     label: 'Failed' },
 }
+
+const SCHEDULABLE_PLATFORMS: Platform[] = ['linkedin', 'facebook', 'instagram']
 
 export default function SchedulerPage() {
   const { data: posts, isLoading } = useScheduledPosts()
   const { data: history } = useCaptionHistory()
   const { data: linkedIn } = useLinkedInStatus()
+  const { data: meta } = useMetaStatus()
   const schedule = useSchedulePost()
 
   const [showForm, setShowForm] = useState(false)
   const [captionId, setCaptionId] = useState('')
   const [platform, setPlatform] = useState<Platform>('linkedin')
   const [scheduledAt, setScheduledAt] = useState('')
+  const [imageUrl, setImageUrl] = useState('')
   const [submitted, setSubmitted] = useState(false)
 
   const minDateTime = new Date(Date.now() + 60_000).toISOString().slice(0, 16)
+
+  const isPlatformConnected = (p: Platform) => {
+    if (p === 'linkedin') return !!linkedIn?.connected
+    if (p === 'facebook') return !!meta?.facebook.connected
+    if (p === 'instagram') return !!meta?.instagram.connected
+    return false
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -41,6 +55,7 @@ export default function SchedulerPage() {
       caption_id: captionId,
       platform,
       scheduled_at: new Date(scheduledAt).toISOString(),
+      ...(platform === 'instagram' && imageUrl ? { image_url: imageUrl } : {}),
     })
     setSubmitted(true)
     setTimeout(() => {
@@ -48,6 +63,7 @@ export default function SchedulerPage() {
       setShowForm(false)
       setCaptionId('')
       setScheduledAt('')
+      setImageUrl('')
     }, 1500)
   }
 
@@ -76,18 +92,16 @@ export default function SchedulerPage() {
         <div className="bg-white rounded-2xl border border-gray-200 p-6 space-y-5">
           <h2 className="font-semibold text-gray-900">New scheduled post</h2>
 
-          {!linkedIn?.connected && (
+          {!isPlatformConnected(platform) && (
             <div className="flex items-center gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
               <Globe className="h-4 w-4 shrink-0" />
-              Connect LinkedIn in Settings before scheduling.
+              Connect {platform.charAt(0).toUpperCase() + platform.slice(1)} in Settings before scheduling.
             </div>
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Caption
-              </label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Caption</label>
               <select
                 required
                 value={captionId}
@@ -97,8 +111,7 @@ export default function SchedulerPage() {
                 <option value="">Select a caption…</option>
                 {history?.map((c) => (
                   <option key={c.id} value={c.id}>
-                    [{c.platform}] {c.topic} —{' '}
-                    {(c.finalText ?? c.generatedText).slice(0, 60)}…
+                    [{c.platform}] {c.topic} — {(c.finalText ?? c.generatedText).slice(0, 60)}…
                   </option>
                 ))}
               </select>
@@ -106,8 +119,8 @@ export default function SchedulerPage() {
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Platform</label>
-              <div className="flex gap-2">
-                {(['linkedin'] as Platform[]).map((p) => (
+              <div className="flex gap-2 flex-wrap">
+                {SCHEDULABLE_PLATFORMS.map((p) => (
                   <button
                     key={p}
                     type="button"
@@ -125,9 +138,26 @@ export default function SchedulerPage() {
               </div>
             </div>
 
+            {platform === 'instagram' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Image URL <span className="text-red-500">*</span>
+                </label>
+                <input
+                  required
+                  type="url"
+                  placeholder="https://example.com/image.jpg"
+                  value={imageUrl}
+                  onChange={(e) => setImageUrl(e.target.value)}
+                  className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+                />
+                <p className="text-xs text-gray-400 mt-1">Must be a publicly accessible URL. Required for Instagram.</p>
+              </div>
+            )}
+
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Publish date & time
+                Publish date &amp; time
               </label>
               <input
                 required
@@ -142,7 +172,7 @@ export default function SchedulerPage() {
             <div className="flex gap-3">
               <button
                 type="submit"
-                disabled={schedule.isPending || !linkedIn?.connected}
+                disabled={schedule.isPending || !isPlatformConnected(platform)}
                 className="flex items-center gap-2 px-5 py-2.5 bg-violet-600 text-white rounded-lg text-sm font-medium hover:bg-violet-700 disabled:opacity-50 transition-colors"
               >
                 {schedule.isPending ? (

--- a/frontend/app/dashboard/settings/page.tsx
+++ b/frontend/app/dashboard/settings/page.tsx
@@ -2,13 +2,13 @@
 
 import { Suspense, useState, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { Loader2, Save, Linkedin, CheckCircle2, XCircle } from 'lucide-react'
+import { Loader2, Save, Linkedin, CheckCircle2, XCircle, Facebook, Instagram } from 'lucide-react'
 import { useUserProfile, useUpdatePreferences, useMLProfile } from '@/hooks/useUserPreferences'
 import { useLinkedInStatus, useLinkedInConnect, useLinkedInDisconnect } from '@/hooks/useLinkedIn'
+import { useMetaStatus, useMetaConnect, useMetaDisconnect } from '@/hooks/useMeta'
 import { LANGUAGES, TONES, PLATFORMS } from '@/constants'
 import type { Language, Tone, Platform, EmojiUsage } from '@/types'
 
-// Isolated so useSearchParams is inside a Suspense boundary
 function LinkedInBanner() {
   const params = useSearchParams()
   const p = params.get('linkedin')
@@ -29,54 +29,144 @@ function LinkedInBanner() {
   return null
 }
 
+function MetaBanner() {
+  const params = useSearchParams()
+  const p = params.get('meta')
+  const reason = params.get('reason')
+  if (p === 'connected')
+    return (
+      <div className="flex items-center gap-2 bg-green-50 border border-green-200 text-green-800 rounded-xl px-4 py-3 text-sm">
+        <CheckCircle2 className="h-4 w-4 shrink-0" />
+        Facebook &amp; Instagram connected successfully!
+      </div>
+    )
+  if (p === 'error')
+    return (
+      <div className="flex items-center gap-2 bg-red-50 border border-red-200 text-red-800 rounded-xl px-4 py-3 text-sm">
+        <XCircle className="h-4 w-4 shrink-0" />
+        {reason === 'no_pages'
+          ? 'No Facebook Pages found. You need at least one Page to connect.'
+          : 'Facebook / Instagram connection failed. Please try again.'}
+      </div>
+    )
+  return null
+}
+
 function LinkedInCard() {
   const { data: status, isLoading } = useLinkedInStatus()
   const connect = useLinkedInConnect()
   const disconnect = useLinkedInDisconnect()
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 p-6">
-      <h2 className="font-semibold text-gray-900 mb-4">Connected Accounts</h2>
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-3">
+        <div className="w-9 h-9 bg-[#0A66C2] rounded-lg flex items-center justify-center">
+          <Linkedin className="h-5 w-5 text-white" />
+        </div>
+        <div>
+          <p className="text-sm font-medium text-gray-900">LinkedIn</p>
+          <p className="text-xs text-gray-400">
+            {isLoading ? 'Checking…' : status?.connected ? `Connected as ${status.username}` : 'Not connected'}
+          </p>
+        </div>
+      </div>
+      {status?.connected ? (
+        <button
+          onClick={() => disconnect.mutate()}
+          disabled={disconnect.isPending}
+          className="px-3 py-1.5 text-sm border border-red-200 text-red-600 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+        >
+          {disconnect.isPending ? <Loader2 className="h-4 w-4 animate-spin inline" /> : 'Disconnect'}
+        </button>
+      ) : (
+        <button
+          onClick={() => connect.mutate()}
+          disabled={connect.isPending || isLoading}
+          className="flex items-center gap-2 px-4 py-1.5 text-sm bg-[#0A66C2] text-white rounded-lg hover:bg-[#004182] transition-colors disabled:opacity-50"
+        >
+          {connect.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Linkedin className="h-4 w-4" />}
+          Connect
+        </button>
+      )}
+    </div>
+  )
+}
+
+function MetaCard() {
+  const { data: status, isLoading } = useMetaStatus()
+  const connect = useMetaConnect()
+  const disconnect = useMetaDisconnect()
+
+  const anyConnected = status?.facebook.connected || status?.instagram.connected
+
+  return (
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <div className="w-9 h-9 bg-[#0A66C2] rounded-lg flex items-center justify-center">
-            <Linkedin className="h-5 w-5 text-white" />
+          <div className="w-9 h-9 bg-[#1877F2] rounded-lg flex items-center justify-center">
+            <Facebook className="h-5 w-5 text-white" />
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-900">LinkedIn</p>
+            <p className="text-sm font-medium text-gray-900">Facebook Page</p>
             <p className="text-xs text-gray-400">
               {isLoading
                 ? 'Checking…'
-                : status?.connected
-                ? `Connected as ${status.username}`
+                : status?.facebook.connected
+                ? `Connected as ${status.facebook.username}`
                 : 'Not connected'}
             </p>
           </div>
         </div>
+        {!anyConnected && (
+          <button
+            onClick={() => connect.mutate()}
+            disabled={connect.isPending || isLoading}
+            className="flex items-center gap-2 px-4 py-1.5 text-sm bg-[#1877F2] text-white rounded-lg hover:bg-[#1668d8] transition-colors disabled:opacity-50"
+          >
+            {connect.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Facebook className="h-4 w-4" />}
+            Connect
+          </button>
+        )}
+      </div>
 
-        {status?.connected ? (
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div
+            className="w-9 h-9 rounded-lg flex items-center justify-center"
+            style={{ background: 'linear-gradient(135deg,#f09433,#e6683c 25%,#dc2743 50%,#cc2366 75%,#bc1888)' }}
+          >
+            <Instagram className="h-5 w-5 text-white" />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-gray-900">Instagram Business</p>
+            <p className="text-xs text-gray-400">
+              {isLoading
+                ? 'Checking…'
+                : status?.instagram.connected
+                ? `Connected as @${status.instagram.username}`
+                : status?.facebook.connected
+                ? 'No Instagram Business Account linked to your Page'
+                : 'Connect Facebook first'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {anyConnected && (
+        <div className="flex justify-end">
           <button
             onClick={() => disconnect.mutate()}
             disabled={disconnect.isPending}
             className="px-3 py-1.5 text-sm border border-red-200 text-red-600 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
           >
-            {disconnect.isPending ? <Loader2 className="h-4 w-4 animate-spin inline" /> : 'Disconnect'}
-          </button>
-        ) : (
-          <button
-            onClick={() => connect.mutate()}
-            disabled={connect.isPending || isLoading}
-            className="flex items-center gap-2 px-4 py-1.5 text-sm bg-[#0A66C2] text-white rounded-lg hover:bg-[#004182] transition-colors disabled:opacity-50"
-          >
-            {connect.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
+            {disconnect.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin inline" />
             ) : (
-              <Linkedin className="h-4 w-4" />
+              'Disconnect Facebook & Instagram'
             )}
-            Connect
           </button>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -131,9 +221,16 @@ export default function SettingsPage() {
 
       <Suspense fallback={null}>
         <LinkedInBanner />
+        <MetaBanner />
       </Suspense>
 
-      <LinkedInCard />
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 space-y-6">
+        <h2 className="font-semibold text-gray-900">Connected Accounts</h2>
+        <LinkedInCard />
+        <div className="border-t border-gray-100 pt-4">
+          <MetaCard />
+        </div>
+      </div>
 
       {mlProfile && (
         <div className="bg-violet-50 border border-violet-200 rounded-xl p-5">

--- a/frontend/components/caption/CaptionCard.tsx
+++ b/frontend/components/caption/CaptionCard.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { useState } from 'react'
-import { Linkedin, Loader2, CheckCircle2, CalendarClock } from 'lucide-react'
+import { Linkedin, Loader2, CheckCircle2, CalendarClock, Facebook, Instagram } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { FeedbackButtons } from './FeedbackButtons'
 import { formatDate } from '@/lib/utils'
 import { useLinkedInStatus, useLinkedInPublish } from '@/hooks/useLinkedIn'
+import { useMetaStatus, usePublishFacebook, usePublishInstagram } from '@/hooks/useMeta'
 import type { Caption } from '@/types'
 
 interface Props {
@@ -16,8 +17,16 @@ interface Props {
 export function CaptionCard({ caption, showFeedback = true }: Props) {
   const router = useRouter()
   const { data: linkedInStatus } = useLinkedInStatus()
+  const { data: metaStatus } = useMetaStatus()
   const publish = useLinkedInPublish()
+  const publishFb = usePublishFacebook()
+  const publishIg = usePublishInstagram()
+
   const [published, setPublished] = useState(false)
+  const [fbPublished, setFbPublished] = useState(false)
+  const [igPublished, setIgPublished] = useState(false)
+  const [showIgForm, setShowIgForm] = useState(false)
+  const [igImageUrl, setIgImageUrl] = useState('')
 
   const fullText =
     (caption.finalText ?? caption.generatedText) +
@@ -28,6 +37,17 @@ export function CaptionCard({ caption, showFeedback = true }: Props) {
   const handlePublish = async () => {
     await publish.mutateAsync({ captionId: caption.id, text: fullText })
     setPublished(true)
+  }
+
+  const handlePublishFacebook = async () => {
+    await publishFb.mutateAsync({ captionId: caption.id, text: fullText })
+    setFbPublished(true)
+  }
+
+  const handlePublishInstagram = async () => {
+    await publishIg.mutateAsync({ captionId: caption.id, text: fullText, imageUrl: igImageUrl })
+    setIgPublished(true)
+    setShowIgForm(false)
   }
 
   return (
@@ -66,7 +86,7 @@ export function CaptionCard({ caption, showFeedback = true }: Props) {
       <div className="flex items-center justify-between gap-2 flex-wrap">
         {showFeedback && <FeedbackButtons caption={caption} />}
 
-        <div className="flex items-center gap-2 ml-auto">
+        <div className="flex items-center gap-2 ml-auto flex-wrap">
           <button
             onClick={() => router.push('/dashboard/scheduler')}
             className="flex items-center gap-1.5 px-3 py-1.5 text-xs border border-gray-200 text-gray-600 rounded-lg hover:border-violet-300 hover:text-violet-600 transition-colors"
@@ -75,29 +95,87 @@ export function CaptionCard({ caption, showFeedback = true }: Props) {
             Schedule
           </button>
 
-        {linkedInStatus?.connected && (
-          published ? (
-            <div className="flex items-center gap-1.5 text-xs text-green-600 font-medium">
-              <CheckCircle2 className="h-3.5 w-3.5" />
-              Posted to LinkedIn
-            </div>
-          ) : (
-            <button
-              onClick={handlePublish}
-              disabled={publish.isPending}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-[#0A66C2] text-white rounded-lg hover:bg-[#004182] transition-colors disabled:opacity-50"
-            >
-              {publish.isPending ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <Linkedin className="h-3 w-3" />
-              )}
-              Post to LinkedIn
-            </button>
-          )
-        )}
+          {linkedInStatus?.connected && (
+            published ? (
+              <div className="flex items-center gap-1.5 text-xs text-green-600 font-medium">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Posted to LinkedIn
+              </div>
+            ) : (
+              <button
+                onClick={handlePublish}
+                disabled={publish.isPending}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-[#0A66C2] text-white rounded-lg hover:bg-[#004182] transition-colors disabled:opacity-50"
+              >
+                {publish.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Linkedin className="h-3 w-3" />}
+                Post to LinkedIn
+              </button>
+            )
+          )}
+
+          {metaStatus?.facebook.connected && (
+            fbPublished ? (
+              <div className="flex items-center gap-1.5 text-xs text-green-600 font-medium">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Posted to Facebook
+              </div>
+            ) : (
+              <button
+                onClick={handlePublishFacebook}
+                disabled={publishFb.isPending}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-[#1877F2] text-white rounded-lg hover:bg-[#1668d8] transition-colors disabled:opacity-50"
+              >
+                {publishFb.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Facebook className="h-3 w-3" />}
+                Post to Facebook
+              </button>
+            )
+          )}
+
+          {metaStatus?.instagram.connected && (
+            igPublished ? (
+              <div className="flex items-center gap-1.5 text-xs text-green-600 font-medium">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                Posted to Instagram
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowIgForm((v) => !v)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-white rounded-lg transition-colors disabled:opacity-50"
+                style={{ background: 'linear-gradient(135deg,#f09433,#e6683c 25%,#dc2743 50%,#cc2366 75%,#bc1888)' }}
+              >
+                <Instagram className="h-3 w-3" />
+                Post to Instagram
+              </button>
+            )
+          )}
         </div>
       </div>
+
+      {showIgForm && !igPublished && (
+        <div className="flex items-center gap-2 pt-1 border-t border-gray-100">
+          <input
+            type="url"
+            placeholder="Public image URL (required for Instagram)"
+            value={igImageUrl}
+            onChange={(e) => setIgImageUrl(e.target.value)}
+            className="flex-1 text-xs border border-gray-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-pink-400"
+          />
+          <button
+            onClick={handlePublishInstagram}
+            disabled={!igImageUrl || publishIg.isPending}
+            className="px-3 py-2 text-xs text-white rounded-lg transition-colors disabled:opacity-50"
+            style={{ background: 'linear-gradient(135deg,#f09433,#e6683c 25%,#dc2743 50%,#cc2366 75%,#bc1888)' }}
+          >
+            {publishIg.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Post'}
+          </button>
+          <button
+            onClick={() => setShowIgForm(false)}
+            className="px-3 py-2 text-xs text-gray-500 hover:text-gray-700 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/hooks/useMeta.ts
+++ b/frontend/hooks/useMeta.ts
@@ -1,0 +1,69 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '@/lib/api'
+import type { ApiResponse } from '@/types'
+
+interface MetaStatus {
+  facebook: { connected: boolean; username?: string }
+  instagram: { connected: boolean; username?: string }
+}
+
+export function useMetaStatus() {
+  return useQuery({
+    queryKey: ['meta-status'],
+    queryFn: async () => {
+      const { data } = await api.get<ApiResponse<MetaStatus>>('/api/meta/status')
+      return data.data
+    },
+  })
+}
+
+export function useMetaConnect() {
+  return useMutation({
+    mutationFn: async () => {
+      const { data } = await api.get<ApiResponse<{ url: string }>>('/api/meta/connect')
+      return data.data.url
+    },
+    onSuccess: (url) => {
+      window.location.href = url
+    },
+  })
+}
+
+export function useMetaDisconnect() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      await api.delete('/api/meta/disconnect')
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['meta-status'] })
+    },
+  })
+}
+
+export function usePublishFacebook() {
+  return useMutation({
+    mutationFn: async ({ captionId, text }: { captionId: string; text: string }) => {
+      const { data } = await api.post<ApiResponse<{ postId: string }>>('/api/meta/publish/facebook', {
+        caption_id: captionId,
+        text,
+      })
+      return data.data
+    },
+  })
+}
+
+export function usePublishInstagram() {
+  return useMutation({
+    mutationFn: async ({ captionId, text, imageUrl }: { captionId: string; text: string; imageUrl: string }) => {
+      const { data } = await api.post<ApiResponse<{ postId: string }>>('/api/meta/publish/instagram', {
+        caption_id: captionId,
+        text,
+        image_url: imageUrl,
+      })
+      return data.data
+    },
+  })
+}

--- a/frontend/hooks/useScheduler.ts
+++ b/frontend/hooks/useScheduler.ts
@@ -23,6 +23,7 @@ export interface ScheduleRequest {
   caption_id: string
   platform: Platform
   scheduled_at: string
+  image_url?: string
 }
 
 export function useScheduledPosts() {

--- a/schema.sql
+++ b/schema.sql
@@ -90,8 +90,12 @@ CREATE TABLE IF NOT EXISTS scheduled_posts (
   scheduled_at     TIMESTAMPTZ NOT NULL,
   status           TEXT DEFAULT 'pending',   -- pending | published | failed
   platform_post_id TEXT,
+  image_url        TEXT,                     -- required for Instagram posts
   created_at       TIMESTAMPTZ DEFAULT NOW()
 );
+
+-- Migration: add image_url if table already exists
+ALTER TABLE scheduled_posts ADD COLUMN IF NOT EXISTS image_url TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_scheduled_posts_user_id      ON scheduled_posts (user_id);
 CREATE INDEX IF NOT EXISTS idx_scheduled_posts_scheduled_at ON scheduled_posts (scheduled_at ASC);


### PR DESCRIPTION
## Summary
- One Meta OAuth flow connects both Facebook Page and Instagram Business Account simultaneously
- Facebook: text post published directly to the user's managed Page (same pattern as LinkedIn)
- Instagram: two-step container + publish flow; CaptionCard shows inline image URL input (required by API)
- Scheduler now supports facebook and instagram platforms; image URL field appears when instagram is selected
- Settings page shows connection status for both platforms with a single Connect/Disconnect button

## Setup required
Add to `backend/.env`:
```
META_APP_ID=your_app_id
META_APP_SECRET=your_app_secret
```
Run the schema migration (or apply `schema.sql`):
```sql
ALTER TABLE scheduled_posts ADD COLUMN IF NOT EXISTS image_url TEXT;
```

## Test plan
- [ ] Click "Connect" in Settings → redirects to Facebook OAuth → returns with both platforms shown as connected
- [ ] `?meta=no_pages` error shown when user has no Facebook Pages
- [ ] Facebook "Post to Facebook" button appears on CaptionCard and publishes successfully
- [ ] Instagram button opens image URL input; post succeeds with valid public image URL
- [ ] Scheduler platform selector shows LinkedIn / Facebook / Instagram; image URL field appears for Instagram
- [ ] Scheduler service publishes facebook and instagram scheduled posts correctly

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)