### PR TITLE
fix(security): validate caption ownership before publishing

### DIFF
--- a/backend/app/routers/linkedin.py
+++ b/backend/app/routers/linkedin.py
@@ -133,6 +133,16 @@ async def linkedin_publish(
             detail="LinkedIn account not connected. Please connect first.",
         )
 
+    caption_check = (
+        db.table("captions")
+        .select("id")
+        .eq("id", req.caption_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not caption_check.data:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Caption not found.")
+
     row = token_row.data[0]
     try:
         result = await linkedin_service.publish_text_post(

--- a/backend/app/routers/meta.py
+++ b/backend/app/routers/meta.py
@@ -155,6 +155,15 @@ async def publish_facebook(
     ).data
     if not row:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Facebook not connected.")
+    caption_check = (
+        db.table("captions")
+        .select("id")
+        .eq("id", req.caption_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not caption_check.data:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Caption not found.")
     try:
         if req.image_url:
             result = await meta_service.publish_facebook_photo(
@@ -197,6 +206,15 @@ async def publish_instagram(
     ).data
     if not row:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Instagram not connected.")
+    caption_check = (
+        db.table("captions")
+        .select("id")
+        .eq("id", req.caption_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not caption_check.data:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Caption not found.")
     try:
         result = await meta_service.publish_instagram_post(
             ig_user_id=row[0]["platform_user_id"],


### PR DESCRIPTION
## Summary
- LinkedIn, Facebook, and Instagram publish endpoints now verify the `caption_id` belongs to the requesting user before publishing
- Returns 403 Forbidden if the caption doesn't exist or belongs to another user

## Test plan
- [ ] Publishing a caption you own works normally
- [ ] Passing another user's `caption_id` returns 403

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)