### PR TITLE
fix(captions): handle malformed Claude JSON response gracefully

### DIFF
--- a/backend/app/services/claude_service.py
+++ b/backend/app/services/claude_service.py
@@ -65,11 +65,23 @@ class ClaudeService:
             messages=[{"role": "user", "content": user_message}],
         )
 
+        if not message.content:
+            raise ValueError("Claude returned an empty response.")
+
         raw = message.content[0].text.strip()
 
         # Strip markdown fences if Claude adds them despite instructions
         raw = re.sub(r"^```(?:json)?\s*", "", raw)
         raw = re.sub(r"\s*```$", "", raw)
 
-        parsed = json.loads(raw)
-        return parsed.get("captions", [])
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Claude returned invalid JSON: {exc}\nRaw response: {raw[:200]}"
+            ) from exc
+
+        captions = parsed.get("captions", [])
+        if not isinstance(captions, list):
+            raise ValueError(f"Unexpected captions format from Claude: {type(captions)}")
+        return captions


### PR DESCRIPTION
## Summary
- Guard against empty `message.content` before indexing
- Wrap `json.loads()` in try/except — raises a descriptive `ValueError` instead of crashing the endpoint with an unhandled `JSONDecodeError`
- Validate the parsed `captions` field is a list before returning

## Test plan
- [ ] Caption generation still works normally
- [ ] Malformed Claude output surfaces as a 500 with a clear error message instead of a raw traceback

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)