### PR TITLE
fix(upload): cap file read at 10 MB to prevent memory exhaustion

### DIFF
--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -27,7 +27,8 @@ async def upload_image(
             detail="Only JPEG, PNG, WebP, and GIF images are allowed.",
         )
 
-    data = await file.read()
+    # Read only up to MAX_BYTES + 1 — avoids loading a huge file fully into memory
+    data = await file.read(MAX_BYTES + 1)
     if len(data) > MAX_BYTES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
## Summary
- Replace unbounded `file.read()` with `file.read(MAX_BYTES + 1)` so the server never loads more than ~10 MB into memory regardless of upload size
- Oversized files are still rejected with a 400 error

## Test plan
- [ ] Uploading a file under 10 MB works normally
- [ ] Uploading a file over 10 MB returns 400 Bad Request

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)