### PR TITLE
fix(security): validate caption ownership in Facebook publish endpoint

### DIFF
--- a/backend/app/routers/meta.py
+++ b/backend/app/routers/meta.py
@@ -155,6 +155,15 @@ async def publish_facebook(
     ).data
     if not row:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Facebook not connected.")
+    caption_check = (
+        db.table("captions")
+        .select("id")
+        .eq("id", req.caption_id)
+        .eq("user_id", user_id)
+        .execute()
+    )
+    if not caption_check.data:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Caption not found.")
     try:
         if req.image_url:
             result = await meta_service.publish_facebook_photo(


### PR DESCRIPTION
## Summary
- Facebook publish endpoint (`POST /api/meta/publish/facebook`) now verifies the `caption_id` belongs to the authenticated user before publishing
- Returns 403 Forbidden if the caption doesn't exist or belongs to another user
- Consistent with the ownership checks being added to LinkedIn and Instagram in PR #34

## Test plan
- [ ] Publishing your own caption to Facebook works normally
- [ ] Passing another user's `caption_id` returns 403

Closes #39
🤖 Generated with [Claude Code](https://claude.com/claude-code)