### PR TITLE
fix(ml): guard against empty caption_ids before Supabase .in_() call

### DIFF
--- a/backend/app/ml/trainer.py
+++ b/backend/app/ml/trainer.py
@@ -35,6 +35,8 @@ class ModelTrainer:
 
         # Fetch related captions (keyed by id)
         caption_ids = list({e["caption_id"] for e in events if e.get("caption_id")})
+        if not caption_ids:
+            return {"error": "No events are linked to captions — cannot train"}
         caps_result = (
             self._db.table("captions")
             .select("id, language, platform, topic, generated_text")


### PR DESCRIPTION
## Summary
- If all user events have a null `caption_id`, the resulting list is empty and Supabase rejects `.in_("id", [])` with an error, crashing the ML trainer
- Added an early return with a descriptive message before the query is made

## Test plan
- [ ] ML training still works normally for users with valid events
- [ ] Users with only null-caption events get a graceful error instead of a crash

Closes #46
🤖 Generated with [Claude Code](https://claude.com/claude-code)