### PR TITLE
fix(security): scope caption updates to owning user in feedback endpoint

### DIFF
--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -54,7 +54,7 @@ async def submit_feedback(
         updates["was_used"] = True
 
     if updates:
-        db.table("captions").update(updates).eq("id", req.caption_id).execute()
+        db.table("captions").update(updates).eq("id", req.caption_id).eq("user_id", user_id).execute()
 
     background_tasks.add_task(_auto_retrain, user_id)
 


### PR DESCRIPTION
## Summary
- `submit_feedback` was calling `.update().eq("id", caption_id)` without `.eq("user_id", user_id)`, allowing any authenticated user to overwrite another user's caption text or flags
- Added the missing owner filter so updates only apply to captions the requester owns

## Test plan
- [ ] Submitting feedback on your own caption still works
- [ ] Submitting feedback with another user's `caption_id` no longer modifies their caption

Closes #47
🤖 Generated with [Claude Code](https://claude.com/claude-code)