### PR TITLE
fix(linkedin): add missing created_at to user_events insert on publish

### DIFF
--- a/backend/app/routers/linkedin.py
+++ b/backend/app/routers/linkedin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import logging
 import secrets
 import traceback
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
@@ -147,6 +148,7 @@ async def linkedin_publish(
             "event_type": "published",
             "caption_id": req.caption_id,
             "metadata": {"platform": "linkedin"},
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }).execute()
 
         return {"success": True, "data": {"post_id": result.get("id", "")}}


### PR DESCRIPTION
## Summary
- LinkedIn publish endpoint inserted `user_events` without a `created_at` field, leaving NULL timestamps in the events table
- NULL timestamps break the personalization engine's time-based feature extraction and analytics queries
- Fixed by adding `datetime.now(timezone.utc).isoformat()` consistently with all other event inserts

## Test plan
- [ ] Publishing to LinkedIn creates a user_event with a valid timestamp
- [ ] Analytics and ML training work correctly after a LinkedIn publish

Closes #48
🤖 Generated with [Claude Code](https://claude.com/claude-code)