### PR TITLE
fix(meta): add missing created_at timestamp to user_events inserts

### DIFF
--- a/backend/app/routers/meta.py
+++ b/backend/app/routers/meta.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import logging
 import secrets
 import traceback
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
@@ -175,6 +176,7 @@ async def publish_facebook(
             "event_type": "published",
             "caption_id": req.caption_id,
             "metadata": {"platform": "facebook"},
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }).execute()
         return {"success": True, "data": {"post_id": result.get("id", "")}}
     except Exception as exc:
@@ -210,6 +212,7 @@ async def publish_instagram(
             "event_type": "published",
             "caption_id": req.caption_id,
             "metadata": {"platform": "instagram"},
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }).execute()
         return {"success": True, "data": {"post_id": result.get("id", "")}}
     except Exception as exc:


### PR DESCRIPTION
## Summary
- Facebook and Instagram user_events inserts were missing created_at, causing NULL timestamps
- Added datetime.now(timezone.utc).isoformat() to both publish endpoints in meta.py

## Test plan
- Publish a caption to Facebook or Instagram
- Verify the user_events row has a non-null created_at timestamp

Generated with Claude Code