### PR TITLE
fix(backend): replace deprecated datetime.utcnow() with timezone-aware calls

### DIFF
--- a/backend/app/ml/trainer.py
+++ b/backend/app/ml/trainer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from supabase import Client
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
@@ -72,7 +72,7 @@ class ModelTrainer:
             "feature_importance": importance,
             "accuracy": accuracy,
             "training_samples": len(df),
-            "last_trained_at": datetime.utcnow().isoformat(),
+            "last_trained_at": datetime.now(timezone.utc).isoformat(),
         }
 
         # Upsert

--- a/backend/app/routers/captions.py
+++ b/backend/app/routers/captions.py
@@ -9,7 +9,7 @@ from app.services import embedding_service
 from app.database import get_supabase
 from app.utils.auth import get_current_user_id
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -64,7 +64,7 @@ async def generate_captions(
         rows = []
         for cap in raw_captions:
             caption_id = str(uuid.uuid4())
-            now = datetime.utcnow().isoformat()
+            now = datetime.now(timezone.utc).isoformat()
             rows.append({
                 "id": caption_id,
                 "user_id": user_id,

--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -7,7 +7,7 @@ from app.utils.auth import get_current_user_id
 from app.ml.trainer import ModelTrainer
 from app.ml.predictor import PersonalizationEngine
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ async def submit_feedback(
         "event_type": req.feedback_type,
         "caption_id": req.caption_id,
         "metadata": {"edited_text": req.edited_text} if req.edited_text else {},
-        "created_at": datetime.utcnow().isoformat(),
+        "created_at": datetime.now(timezone.utc).isoformat(),
     }
     db.table("user_events").insert(event).execute()
 


### PR DESCRIPTION
## Summary
- datetime.utcnow() is deprecated in Python 3.12+ and produces naive datetimes
- Replaced with datetime.now(timezone.utc) in captions.py, feedback.py, and trainer.py

## Test plan
- Generate captions and submit feedback
- Verify no deprecation warnings in backend logs

Generated with Claude Code