### PR TITLE
fix(backend): handle Z-suffix ISO timestamps in caption history endpoint

### DIFF
--- a/backend/app/routers/captions.py
+++ b/backend/app/routers/captions.py
@@ -143,7 +143,7 @@ async def get_history(
                 was_liked=r.get("was_liked", False),
                 was_edited=r.get("was_edited", False),
                 final_text=r.get("final_text"),
-                created_at=datetime.fromisoformat(r["created_at"]),
+                created_at=datetime.fromisoformat(r["created_at"].replace("Z", "+00:00")),
             )
             for r in rows
         ]


### PR DESCRIPTION
## Summary
- Python's datetime.fromisoformat() crashes on timestamps ending in Z (e.g. 2024-01-01T00:00:00Z) in Python < 3.11
- Added .replace('Z', '+00:00') before parsing in the caption history endpoint

## Test plan
- Open the caption history page
- Verify captions load without 500 errors

Generated with Claude Code