### PR TITLE
fix(frontend): log publish errors in useMeta hooks

### DIFF
--- a/frontend/hooks/useMeta.ts
+++ b/frontend/hooks/useMeta.ts
@@ -53,6 +53,9 @@ export function usePublishFacebook() {
       })
       return data.data
     },
+    onError: (err: Error) => {
+      console.error('[Facebook publish]', err.message)
+    },
   })
 }
 
@@ -65,6 +68,9 @@ export function usePublishInstagram() {
         image_url: imageUrl,
       })
       return data.data
+    },
+    onError: (err: Error) => {
+      console.error('[Instagram publish]', err.message)
     },
   })
 }


### PR DESCRIPTION
## Summary
- usePublishFacebook and usePublishInstagram mutations had no error handling
- Added onError handlers that log the error message to the console for easier debugging

## Test plan
- Trigger a Facebook or Instagram publish failure
- Open browser devtools and verify the error is logged

Generated with Claude Code