### PR TITLE
fix(security): scope caption was_used update to owning user on publish

### DIFF
--- a/backend/app/routers/linkedin.py
+++ b/backend/app/routers/linkedin.py
@@ -141,7 +141,7 @@ async def linkedin_publish(
             text=req.text,
         )
 
-        db.table("captions").update({"was_used": True}).eq("id", req.caption_id).execute()
+        db.table("captions").update({"was_used": True}).eq("id", req.caption_id).eq("user_id", user_id).execute()
         db.table("user_events").insert({
             "user_id": user_id,
             "event_type": "published",

--- a/backend/app/routers/meta.py
+++ b/backend/app/routers/meta.py
@@ -169,7 +169,7 @@ async def publish_facebook(
                 page_access_token=row[0]["access_token"],
                 text=req.text,
             )
-        db.table("captions").update({"was_used": True}).eq("id", req.caption_id).execute()
+        db.table("captions").update({"was_used": True}).eq("id", req.caption_id).eq("user_id", user_id).execute()
         db.table("user_events").insert({
             "user_id": user_id,
             "event_type": "published",
@@ -204,7 +204,7 @@ async def publish_instagram(
             image_url=req.image_url,
             caption=req.text,
         )
-        db.table("captions").update({"was_used": True}).eq("id", req.caption_id).execute()
+        db.table("captions").update({"was_used": True}).eq("id", req.caption_id).eq("user_id", user_id).execute()
         db.table("user_events").insert({
             "user_id": user_id,
             "event_type": "published",


### PR DESCRIPTION
Closes #65

## Summary
- publish_facebook, publish_instagram (meta.py), and linkedin_publish (linkedin.py) updated captions.was_used without verifying the caption belongs to the current user
- Any authenticated user could mark another user's caption as used by guessing its ID
- Added .eq('user_id', user_id) to all three caption update calls

## Test plan
- Attempt to publish a caption owned by a different user - verify it no longer updates their caption

Generated with Claude Code