### PR TITLE
fix(backend): add missing created_at to user_events inserts in publish endpoints

### DIFF
--- a/backend/app/routers/linkedin.py
+++ b/backend/app/routers/linkedin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import logging
 import secrets
 import traceback
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
@@ -147,6 +148,7 @@ async def linkedin_publish(
             "event_type": "published",
             "caption_id": req.caption_id,
             "metadata": {"platform": "linkedin"},
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }).execute()
 
         return {"success": True, "data": {"post_id": result.get("id", "")}}

--- a/backend/app/routers/meta.py
+++ b/backend/app/routers/meta.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import logging
 import secrets
 import traceback
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
@@ -175,6 +176,7 @@ async def publish_facebook(
             "event_type": "published",
             "caption_id": req.caption_id,
             "metadata": {"platform": "facebook"},
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }).execute()
         return {"success": True, "data": {"post_id": result.get("id", "")}}
     except Exception as exc:
@@ -210,6 +212,7 @@ async def publish_instagram(
             "event_type": "published",
             "caption_id": req.caption_id,
             "metadata": {"platform": "instagram"},
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }).execute()
         return {"success": True, "data": {"post_id": result.get("id", "")}}
     except Exception as exc:


### PR DESCRIPTION
Closes #66

## Summary
- user_events inserts in publish_facebook, publish_instagram (meta.py), and linkedin_publish (linkedin.py) were missing the created_at field
- This caused NULL timestamps in the events table, breaking analytics and audit trails
- Added datetime.now(timezone.utc).isoformat() to all three inserts

## Test plan
- Publish to LinkedIn, Facebook, or Instagram
- Check user_events table - verify created_at is populated

Generated with Claude Code