### PR TITLE
fix(scheduler): mark posts as failed when token missing or no IG image

### DIFF
--- a/backend/app/services/scheduler_service.py
+++ b/backend/app/services/scheduler_service.py
@@ -50,9 +50,16 @@ async def run_scheduler() -> dict:
                 text += "\n\n" + " ".join(h if h.startswith("#") else f"#{h}" for h in hashtags)
 
             token_row = tokens.get(platform, {}).get(user_id)
+
+            if not token_row:
+                log.warning("Skipping post %s — no token for %s", post["id"], platform)
+                db.table("scheduled_posts").update({"status": "failed"}).eq("id", post["id"]).execute()
+                failed += 1
+                continue
+
             post_id = None
 
-            if platform == "linkedin" and token_row:
+            if platform == "linkedin":
                 result = await linkedin_service.publish_text_post(
                     access_token=token_row["access_token"],
                     person_urn=token_row["platform_user_id"],
@@ -60,7 +67,7 @@ async def run_scheduler() -> dict:
                 )
                 post_id = result.get("id")
 
-            elif platform == "facebook" and token_row:
+            elif platform == "facebook":
                 result = await meta_service.publish_facebook_post(
                     page_id=token_row["platform_user_id"],
                     page_access_token=token_row["access_token"],
@@ -68,18 +75,20 @@ async def run_scheduler() -> dict:
                 )
                 post_id = result.get("id")
 
-            elif platform == "instagram" and token_row:
+            elif platform == "instagram":
                 image_url = post.get("image_url")
-                if image_url:
-                    result = await meta_service.publish_instagram_post(
-                        ig_user_id=token_row["platform_user_id"],
-                        page_access_token=token_row["access_token"],
-                        image_url=image_url,
-                        caption=text,
-                    )
-                    post_id = result.get("id")
-                else:
+                if not image_url:
                     log.warning("Skipping Instagram post %s — no image_url", post["id"])
+                    db.table("scheduled_posts").update({"status": "failed"}).eq("id", post["id"]).execute()
+                    failed += 1
+                    continue
+                result = await meta_service.publish_instagram_post(
+                    ig_user_id=token_row["platform_user_id"],
+                    page_access_token=token_row["access_token"],
+                    image_url=image_url,
+                    caption=text,
+                )
+                post_id = result.get("id")
 
             db.table("scheduled_posts").update({
                 "status": "published",


### PR DESCRIPTION
Closes #70

## Summary
- scheduler_service.py marked every processed post as 'published' even if it never actually published
- If token_row is None: now marks as 'failed' and continues to the next post
- If Instagram has no image_url: now marks as 'failed' and continues
- Only reaches the 'published' update after a successful publish call

## Test plan
- Schedule a post for a platform whose token has been disconnected
- Verify the post status becomes 'failed' instead of 'published'

Generated with Claude Code