### PR TITLE
fix(scheduler): show error state when scheduling a post fails

### DIFF
--- a/frontend/app/dashboard/scheduler/page.tsx
+++ b/frontend/app/dashboard/scheduler/page.tsx
@@ -51,20 +51,24 @@ export default function SchedulerPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await schedule.mutateAsync({
-      caption_id: captionId,
-      platform,
-      scheduled_at: new Date(scheduledAt).toISOString(),
-      ...(platform === 'instagram' && imageUrl ? { image_url: imageUrl } : {}),
-    })
-    setSubmitted(true)
-    setTimeout(() => {
-      setSubmitted(false)
-      setShowForm(false)
-      setCaptionId('')
-      setScheduledAt('')
-      setImageUrl('')
-    }, 1500)
+    try {
+      await schedule.mutateAsync({
+        caption_id: captionId,
+        platform,
+        scheduled_at: new Date(scheduledAt).toISOString(),
+        ...(platform === 'instagram' && imageUrl ? { image_url: imageUrl } : {}),
+      })
+      setSubmitted(true)
+      setTimeout(() => {
+        setSubmitted(false)
+        setShowForm(false)
+        setCaptionId('')
+        setScheduledAt('')
+        setImageUrl('')
+      }, 1500)
+    } catch {
+      // error is surfaced via schedule.isError below
+    }
   }
 
   const pending = posts?.filter((p) => p.status === 'pending') ?? []
@@ -168,6 +172,10 @@ export default function SchedulerPage() {
                 className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
               />
             </div>
+
+            {schedule.isError && (
+              <p className="text-xs text-red-500">Failed to schedule — try again.</p>
+            )}
 
             <div className="flex gap-3">
               <button

--- a/frontend/hooks/useScheduler.ts
+++ b/frontend/hooks/useScheduler.ts
@@ -47,5 +47,8 @@ export function useSchedulePost() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['scheduled-posts'] })
     },
+    onError: (err: Error) => {
+      console.error('[schedule post]', err.message)
+    },
   })
 }


### PR DESCRIPTION
Closes #71

## Summary
- handleSubmit called mutateAsync without try/catch; React Query threw on failure and left the form in an inconsistent state with no error shown
- Added try/catch so the form stays open and usable after failure
- Added schedule.isError display above the submit button
- Added onError console logging to useSchedulePost

## Test plan
- Submit the schedule form while the backend is unreachable
- Verify 'Failed to schedule - try again.' appears and the form stays open

Generated with Claude Code