### PR TITLE
fix(config): use settings.backend_url for OAuth REDIRECT_URI

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     supabase_service_key: str = ""
     anthropic_api_key: str = ""
     frontend_url: str = "http://localhost:3000"
+    backend_url: str = "http://localhost:8000"
 
     # Optional social platform keys
     meta_app_id: str = ""

--- a/backend/app/routers/linkedin.py
+++ b/backend/app/routers/linkedin.py
@@ -14,7 +14,7 @@ from app.services import linkedin_service
 router = APIRouter()
 log = logging.getLogger(__name__)
 
-REDIRECT_URI = "http://localhost:8000/api/linkedin/callback"
+REDIRECT_URI = f"{settings.backend_url}/api/linkedin/callback"
 
 
 @router.get("/connect")

--- a/backend/app/routers/meta.py
+++ b/backend/app/routers/meta.py
@@ -14,7 +14,7 @@ from app.services import meta_service
 router = APIRouter()
 log = logging.getLogger(__name__)
 
-REDIRECT_URI = "http://localhost:8000/api/meta/callback"
+REDIRECT_URI = f"{settings.backend_url}/api/meta/callback"
 
 
 @router.get("/connect")


### PR DESCRIPTION
Closes #72

## Summary
- REDIRECT_URI in linkedin.py and meta.py was hardcoded to http://localhost:8000
- OAuth callbacks would point to localhost in production, breaking authentication entirely
- Added backend_url setting to config.py (defaults to http://localhost:8000 for local dev)
- Both routers now use settings.backend_url for their REDIRECT_URI

## Test plan
- Set BACKEND_URL=https://api.example.com in .env
- Verify /api/linkedin/connect and /api/meta/connect return redirect URIs pointing to that domain

Generated with Claude Code