### PR TITLE
fix(upload): cap file read at MAX_BYTES+1 to prevent OOM on oversized uploads

### DIFF
--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -27,7 +27,7 @@ async def upload_image(
             detail="Only JPEG, PNG, WebP, and GIF images are allowed.",
         )
 
-    data = await file.read()
+    data = await file.read(MAX_BYTES + 1)
     if len(data) > MAX_BYTES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
Closes #73

## Summary
- upload.py read the entire uploaded file into memory before checking the size limit
- A malicious client could send a multi-GB file, exhausting server memory
- Changed to file.read(MAX_BYTES + 1) to read at most 10MB+1 bytes
- The size check still works: if we got more than MAX_BYTES bytes the upload is rejected

## Test plan
- Upload a file larger than 10 MB
- Verify the 400 error is returned without loading the full file into memory

Generated with Claude Code