### PR TITLE
fix(frontend): only close caption editor after save succeeds

### DIFF
--- a/frontend/components/caption/FeedbackButtons.tsx
+++ b/frontend/components/caption/FeedbackButtons.tsx
@@ -38,12 +38,10 @@ export function FeedbackButtons({ caption }: Props) {
   }
 
   const handleSaveEdit = () => {
-    submitFeedback({
-      captionId: caption.id,
-      feedbackType: 'edited',
-      editedText: editText,
-    })
-    setEditing(false)
+    submitFeedback(
+      { captionId: caption.id, feedbackType: 'edited', editedText: editText },
+      { onSuccess: () => setEditing(false) },
+    )
   }
 
   return (


### PR DESCRIPTION
Closes #79

## Summary
- handleSaveEdit called setEditing(false) immediately after submitFeedback, before the async mutation resolved
- If the API call failed, the editor closed and the user lost their edits with no error shown
- Fixed by passing onSuccess callback to mutate so the editor only closes after a successful save

## Test plan
- Edit a caption and click Save while the backend is unreachable
- Verify the editor stays open so the user can retry

Generated with Claude Code