### PR TITLE
fix(users): replace single() with maybe_single() to fix new user login

### DIFF
--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -12,7 +12,7 @@ router = APIRouter()
 @router.get("/profile", response_model=dict)
 async def get_profile(user_id: str = Depends(get_current_user_id)):
     db = get_supabase()
-    result = db.table("user_profiles").select("*").eq("id", user_id).single().execute()
+    result = db.table("user_profiles").select("*").eq("id", user_id).maybe_single().execute()
 
     if not result.data:
         # Auto-create profile on first access
@@ -54,7 +54,7 @@ async def update_preferences(
     updates = req.model_dump(exclude_none=True)
     updates["updated_at"] = datetime.now(timezone.utc).isoformat()
     db.table("user_profiles").update(updates).eq("id", user_id).execute()
-    result = db.table("user_profiles").select("*").eq("id", user_id).single().execute()
+    result = db.table("user_profiles").select("*").eq("id", user_id).maybe_single().execute()
     data = result.data
     profile = UserProfile(
         id=data["id"],


### PR DESCRIPTION
Closes #85

With supabase-py v2, .single() raises APIError when no rows are found. get_profile used .single() then checked 'if not result.data' to auto-create a profile for new users, but that branch was never reached. Every new user login hit a 500 error.

Fix: .single() replaced with .maybe_single() in get_profile and update_preferences.