### PR TITLE
fix(captions): use request language/tone in system prompt, not profile default

### DIFF
--- a/backend/app/services/claude_service.py
+++ b/backend/app/services/claude_service.py
@@ -53,7 +53,8 @@ class ClaudeService:
         user_profile: dict,
         similar_captions: list[str],
     ) -> list[dict]:
-        system = build_system_prompt(user_profile, similar_captions)
+        effective_profile = {**user_profile, "preferred_language": language, "preferred_tone": tone}
+        system = build_system_prompt(effective_profile, similar_captions)
         user_message = (
             f"Generate {count} {tone} {language} captions for {platform} about: {topic}"
         )


### PR DESCRIPTION
Closes #87

## Root cause
uild_system_prompt() read language from user_profile.get('preferred_language', 'english'). When a user selects Hindi in the UI, the request language only appeared in the user message (Generate … hindi captions), but the **system prompt rule** said Write ONLY in english, which Claude follows more strictly — producing English captions regardless of selection.

## Fix
Before calling uild_system_prompt, merge the request's explicit language and 	one into the profile:
\\\python
effective_profile = {**user_profile, 'preferred_language': language, 'preferred_tone': tone}
system = build_system_prompt(effective_profile, similar_captions)
\\\
The system prompt rule now correctly reflects whatever language the user selects.