### PR TITLE
feat(frontend): add dark/light mode toggle

### DIFF
--- a/frontend/app/dashboard/analytics/page.tsx
+++ b/frontend/app/dashboard/analytics/page.tsx
@@ -16,25 +16,25 @@ export default function AnalyticsPage() {
   const statCards = useMemo(() => {
     if (!data) return []
     return [
-      { label: 'Total Captions', value: data.totals.captions, icon: BarChart3, color: 'text-violet-600 bg-violet-50' },
-      { label: 'Liked', value: data.totals.liked, icon: Heart, color: 'text-pink-600 bg-pink-50' },
-      { label: 'Copied / Used', value: data.totals.used, icon: Copy, color: 'text-blue-600 bg-blue-50' },
-      { label: 'Edited', value: data.totals.edited, icon: PenLine, color: 'text-amber-600 bg-amber-50' },
-      { label: 'Published', value: data.totals.published, icon: Send, color: 'text-green-600 bg-green-50' },
-      { label: 'Total Events', value: data.totals.events, icon: Zap, color: 'text-gray-600 bg-gray-100' },
+      { label: 'Total Captions', value: data.totals.captions, icon: BarChart3, color: 'text-violet-600 bg-violet-50 dark:bg-violet-950 dark:text-violet-400' },
+      { label: 'Liked', value: data.totals.liked, icon: Heart, color: 'text-pink-600 bg-pink-50 dark:bg-pink-950 dark:text-pink-400' },
+      { label: 'Copied / Used', value: data.totals.used, icon: Copy, color: 'text-blue-600 bg-blue-50 dark:bg-blue-950 dark:text-blue-400' },
+      { label: 'Edited', value: data.totals.edited, icon: PenLine, color: 'text-amber-600 bg-amber-50 dark:bg-amber-950 dark:text-amber-400' },
+      { label: 'Published', value: data.totals.published, icon: Send, color: 'text-green-600 bg-green-50 dark:bg-green-950 dark:text-green-400' },
+      { label: 'Total Events', value: data.totals.events, icon: Zap, color: 'text-gray-600 bg-gray-100 dark:bg-gray-800 dark:text-gray-300' },
     ]
   }, [data])
 
   if (isLoading)
     return (
-      <div className="flex items-center justify-center py-20 text-gray-400">
+      <div className="flex items-center justify-center py-20 text-gray-400 dark:text-gray-500">
         <Loader2 className="h-6 w-6 animate-spin mr-2" /> Loading analytics…
       </div>
     )
 
   if (error || !data)
     return (
-      <div className="py-20 text-center text-gray-400">
+      <div className="py-20 text-center text-gray-400 dark:text-gray-500">
         Could not load analytics. Generate some captions first!
       </div>
     )
@@ -44,24 +44,24 @@ export default function AnalyticsPage() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Analytics</h1>
-        <p className="text-gray-500 mt-1">Your caption performance at a glance.</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Analytics</h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">Your caption performance at a glance.</p>
       </div>
 
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4">
         {statCards.map(({ label, value, icon: Icon, color }) => (
-          <div key={label} className="bg-white rounded-2xl border border-gray-200 p-4 space-y-2">
+          <div key={label} className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-4 space-y-2">
             <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${color}`}>
               <Icon className="h-4 w-4" />
             </div>
-            <p className="text-2xl font-bold text-gray-900">{value}</p>
-            <p className="text-xs text-gray-400">{label}</p>
+            <p className="text-2xl font-bold text-gray-900 dark:text-white">{value}</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500">{label}</p>
           </div>
         ))}
       </div>
 
-      <div className="bg-white rounded-2xl border border-gray-200 p-6">
-        <h2 className="font-semibold text-gray-900 mb-4">Captions generated — last 14 days</h2>
+      <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+        <h2 className="font-semibold text-gray-900 dark:text-white mb-4">Captions generated — last 14 days</h2>
         <ResponsiveContainer width="100%" height={200}>
           <LineChart data={captionsPerDay}>
             <XAxis dataKey="date" tick={{ fontSize: 11 }} interval={1} />
@@ -73,8 +73,8 @@ export default function AnalyticsPage() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="bg-white rounded-2xl border border-gray-200 p-6">
-          <h2 className="font-semibold text-gray-900 mb-4">Top platforms</h2>
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="font-semibold text-gray-900 dark:text-white mb-4">Top platforms</h2>
           <ResponsiveContainer width="100%" height={200}>
             <BarChart data={topPlatforms} layout="vertical">
               <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
@@ -85,8 +85,8 @@ export default function AnalyticsPage() {
           </ResponsiveContainer>
         </div>
 
-        <div className="bg-white rounded-2xl border border-gray-200 p-6">
-          <h2 className="font-semibold text-gray-900 mb-4">Top tones</h2>
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="font-semibold text-gray-900 dark:text-white mb-4">Top tones</h2>
           <ResponsiveContainer width="100%" height={200}>
             <PieChart>
               <Pie
@@ -108,8 +108,8 @@ export default function AnalyticsPage() {
           </ResponsiveContainer>
         </div>
 
-        <div className="bg-white rounded-2xl border border-gray-200 p-6">
-          <h2 className="font-semibold text-gray-900 mb-4">Languages used</h2>
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="font-semibold text-gray-900 dark:text-white mb-4">Languages used</h2>
           <ResponsiveContainer width="100%" height={200}>
             <BarChart data={topLanguages}>
               <XAxis dataKey="language" tick={{ fontSize: 11 }} />
@@ -120,8 +120,8 @@ export default function AnalyticsPage() {
           </ResponsiveContainer>
         </div>
 
-        <div className="bg-white rounded-2xl border border-gray-200 p-6">
-          <h2 className="font-semibold text-gray-900 mb-4">Likes by platform</h2>
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6">
+          <h2 className="font-semibold text-gray-900 dark:text-white mb-4">Likes by platform</h2>
           <ResponsiveContainer width="100%" height={200}>
             <BarChart data={engagementByPlatform}>
               <XAxis dataKey="platform" tick={{ fontSize: 11 }} />

--- a/frontend/app/dashboard/history/page.tsx
+++ b/frontend/app/dashboard/history/page.tsx
@@ -10,25 +10,25 @@ export default function HistoryPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Caption History</h1>
-        <p className="text-gray-500 mt-1">All captions you&apos;ve generated.</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Caption History</h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">All captions you&apos;ve generated.</p>
       </div>
 
       {isLoading && (
-        <div className="flex items-center gap-2 text-gray-400 py-12 justify-center">
+        <div className="flex items-center gap-2 text-gray-400 dark:text-gray-500 py-12 justify-center">
           <Loader2 className="h-5 w-5 animate-spin" />
           <span>Loading history…</span>
         </div>
       )}
 
       {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg px-4 py-3 text-sm">
+        <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 rounded-lg px-4 py-3 text-sm">
           Failed to load history. Please refresh.
         </div>
       )}
 
       {captions && captions.length === 0 && (
-        <div className="text-center py-20 text-gray-400">
+        <div className="text-center py-20 text-gray-400 dark:text-gray-500">
           <HistoryIcon className="h-12 w-12 mx-auto mb-4 opacity-30" />
           <p className="font-medium">No captions yet</p>
           <p className="text-sm mt-1">Generate your first caption to see it here.</p>

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -35,8 +35,8 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   if (!user) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="flex flex-col items-center gap-3 text-gray-400">
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
+        <div className="flex flex-col items-center gap-3 text-gray-400 dark:text-gray-500">
           <Loader2 className="h-8 w-8 animate-spin" />
           <p className="text-sm">Loading...</p>
         </div>
@@ -45,7 +45,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <Navbar />
       <div className="flex">
         <Sidebar />

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -4,8 +4,8 @@ export default function DashboardPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Caption Generator</h1>
-        <p className="text-gray-500 mt-1">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Caption Generator</h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">
           Describe your topic and let AI craft the perfect caption for you.
         </p>
       </div>

--- a/frontend/app/dashboard/scheduler/page.tsx
+++ b/frontend/app/dashboard/scheduler/page.tsx
@@ -19,9 +19,9 @@ const PLATFORM_ICONS: Record<string, React.ReactNode> = {
 }
 
 const STATUS_CONFIG = {
-  pending:   { icon: Clock,        color: 'text-amber-600 bg-amber-50', label: 'Pending' },
-  published: { icon: CheckCircle2, color: 'text-green-600 bg-green-50', label: 'Published' },
-  failed:    { icon: XCircle,      color: 'text-red-600 bg-red-50',     label: 'Failed' },
+  pending:   { icon: Clock,        color: 'text-amber-600 bg-amber-50 dark:bg-amber-950 dark:text-amber-400', label: 'Pending' },
+  published: { icon: CheckCircle2, color: 'text-green-600 bg-green-50 dark:bg-green-950 dark:text-green-400', label: 'Published' },
+  failed:    { icon: XCircle,      color: 'text-red-600 bg-red-50 dark:bg-red-950 dark:text-red-400',         label: 'Failed' },
 }
 
 const SCHEDULABLE_PLATFORMS: Platform[] = ['linkedin', 'facebook', 'instagram']
@@ -74,8 +74,8 @@ export default function SchedulerPage() {
     <div className="space-y-8 max-w-3xl">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Post Scheduler</h1>
-          <p className="text-gray-500 mt-1">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Post Scheduler</h1>
+          <p className="text-gray-500 dark:text-gray-400 mt-1">
             Schedule captions to auto-publish. The backend checks every minute.
           </p>
         </div>
@@ -89,24 +89,28 @@ export default function SchedulerPage() {
       </div>
 
       {showForm && (
-        <div className="bg-white rounded-2xl border border-gray-200 p-6 space-y-5">
-          <h2 className="font-semibold text-gray-900">New scheduled post</h2>
+        <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-5">
+          <h2 className="font-semibold text-gray-900 dark:text-white">New scheduled post</h2>
 
           {!isPlatformConnected(platform) && (
-            <div className="flex items-center gap-2 bg-amber-50 border border-amber-200 text-amber-800 rounded-xl px-4 py-3 text-sm">
+            <div className="flex items-center gap-2 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-400 rounded-xl px-4 py-3 text-sm">
               <Globe className="h-4 w-4 shrink-0" />
               Connect {platform.charAt(0).toUpperCase() + platform.slice(1)} in Settings before scheduling.
             </div>
           )}
 
+          {schedule.isError && (
+            <p className="text-xs text-red-500 dark:text-red-400">Failed to schedule — try again.</p>
+          )}
+
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Caption</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Caption</label>
               <select
                 required
                 value={captionId}
                 onChange={(e) => setCaptionId(e.target.value)}
-                className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+                className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
               >
                 <option value="">Select a caption…</option>
                 {history?.map((c) => (
@@ -118,7 +122,7 @@ export default function SchedulerPage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Platform</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Platform</label>
               <div className="flex gap-2 flex-wrap">
                 {SCHEDULABLE_PLATFORMS.map((p) => (
                   <button
@@ -128,7 +132,7 @@ export default function SchedulerPage() {
                     className={`flex items-center gap-2 px-4 py-2 rounded-lg border text-sm capitalize transition-colors ${
                       platform === p
                         ? 'bg-violet-600 text-white border-violet-600'
-                        : 'border-gray-200 text-gray-600 hover:border-violet-300'
+                        : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-violet-300'
                     }`}
                   >
                     {PLATFORM_ICONS[p] ?? <Globe className="h-4 w-4" />}
@@ -140,7 +144,7 @@ export default function SchedulerPage() {
 
             {platform === 'instagram' && (
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Image URL <span className="text-red-500">*</span>
                 </label>
                 <input
@@ -149,14 +153,14 @@ export default function SchedulerPage() {
                   placeholder="https://example.com/image.jpg"
                   value={imageUrl}
                   onChange={(e) => setImageUrl(e.target.value)}
-                  className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+                  className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500"
                 />
-                <p className="text-xs text-gray-400 mt-1">Must be a publicly accessible URL. Required for Instagram.</p>
+                <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">Must be a publicly accessible URL. Required for Instagram.</p>
               </div>
             )}
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Publish date &amp; time
               </label>
               <input
@@ -165,7 +169,7 @@ export default function SchedulerPage() {
                 min={minDateTime}
                 value={scheduledAt}
                 onChange={(e) => setScheduledAt(e.target.value)}
-                className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+                className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
               />
             </div>
 
@@ -185,7 +189,7 @@ export default function SchedulerPage() {
               <button
                 type="button"
                 onClick={() => setShowForm(false)}
-                className="px-4 py-2.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                className="px-4 py-2.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
               >
                 Cancel
               </button>
@@ -195,16 +199,16 @@ export default function SchedulerPage() {
       )}
 
       <section className="space-y-3">
-        <h2 className="font-semibold text-gray-700 text-sm uppercase tracking-wide">
+        <h2 className="font-semibold text-gray-700 dark:text-gray-300 text-sm uppercase tracking-wide">
           Upcoming ({pending.length})
         </h2>
         {isLoading ? (
-          <div className="flex items-center gap-2 text-gray-400 py-8 justify-center">
+          <div className="flex items-center gap-2 text-gray-400 dark:text-gray-500 py-8 justify-center">
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
         ) : pending.length === 0 ? (
-          <div className="bg-white rounded-2xl border border-gray-200 p-10 text-center text-gray-400 text-sm">
-            No upcoming posts. Click "Schedule post" to add one.
+          <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-10 text-center text-gray-400 dark:text-gray-500 text-sm">
+            No upcoming posts. Click &quot;Schedule post&quot; to add one.
           </div>
         ) : (
           pending.map((post) => <PostCard key={post.id} post={post} />)
@@ -213,7 +217,7 @@ export default function SchedulerPage() {
 
       {pastPosts.length > 0 && (
         <section className="space-y-3">
-          <h2 className="font-semibold text-gray-700 text-sm uppercase tracking-wide">
+          <h2 className="font-semibold text-gray-700 dark:text-gray-300 text-sm uppercase tracking-wide">
             Past ({pastPosts.length})
           </h2>
           {pastPosts.map((post) => (
@@ -233,26 +237,26 @@ function PostCard({ post }: { post: ReturnType<typeof useScheduledPosts>['data']
   const text = caption?.finalText ?? caption?.generatedText ?? ''
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 p-5 flex gap-4">
+    <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 flex gap-4">
       <div className="flex-1 space-y-2 min-w-0">
         <div className="flex items-center gap-2 flex-wrap">
           <span className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium ${cfg.color}`}>
             <StatusIcon className="h-3 w-3" />
             {cfg.label}
           </span>
-          <span className="flex items-center gap-1.5 text-xs text-gray-500 capitalize">
+          <span className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 capitalize">
             {PLATFORM_ICONS[post.platform] ?? <Globe className="h-3.5 w-3.5" />}
             {post.platform}
           </span>
-          <span className="ml-auto text-xs text-gray-400">
+          <span className="ml-auto text-xs text-gray-400 dark:text-gray-500">
             {formatDate(post.scheduledAt)}
           </span>
         </div>
         {caption?.topic && (
-          <p className="text-xs text-gray-400 font-medium">Topic: {caption.topic}</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 font-medium">Topic: {caption.topic}</p>
         )}
         {text && (
-          <p className="text-sm text-gray-700 line-clamp-2">{text}</p>
+          <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-2">{text}</p>
         )}
       </div>
     </div>

--- a/frontend/app/dashboard/settings/page.tsx
+++ b/frontend/app/dashboard/settings/page.tsx
@@ -14,14 +14,14 @@ function LinkedInBanner() {
   const p = params.get('linkedin')
   if (p === 'connected')
     return (
-      <div className="flex items-center gap-2 bg-green-50 border border-green-200 text-green-800 rounded-xl px-4 py-3 text-sm">
+      <div className="flex items-center gap-2 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-400 rounded-xl px-4 py-3 text-sm">
         <CheckCircle2 className="h-4 w-4 shrink-0" />
         LinkedIn connected successfully!
       </div>
     )
   if (p === 'error')
     return (
-      <div className="flex items-center gap-2 bg-red-50 border border-red-200 text-red-800 rounded-xl px-4 py-3 text-sm">
+      <div className="flex items-center gap-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-400 rounded-xl px-4 py-3 text-sm">
         <XCircle className="h-4 w-4 shrink-0" />
         LinkedIn connection failed. Please try again.
       </div>
@@ -35,14 +35,14 @@ function MetaBanner() {
   const reason = params.get('reason')
   if (p === 'connected')
     return (
-      <div className="flex items-center gap-2 bg-green-50 border border-green-200 text-green-800 rounded-xl px-4 py-3 text-sm">
+      <div className="flex items-center gap-2 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-400 rounded-xl px-4 py-3 text-sm">
         <CheckCircle2 className="h-4 w-4 shrink-0" />
         Facebook &amp; Instagram connected successfully!
       </div>
     )
   if (p === 'error')
     return (
-      <div className="flex items-center gap-2 bg-red-50 border border-red-200 text-red-800 rounded-xl px-4 py-3 text-sm">
+      <div className="flex items-center gap-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-800 dark:text-red-400 rounded-xl px-4 py-3 text-sm">
         <XCircle className="h-4 w-4 shrink-0" />
         {reason === 'no_pages'
           ? 'No Facebook Pages found. You need at least one Page to connect.'
@@ -64,8 +64,8 @@ function LinkedInCard() {
           <Linkedin className="h-5 w-5 text-white" />
         </div>
         <div>
-          <p className="text-sm font-medium text-gray-900">LinkedIn</p>
-          <p className="text-xs text-gray-400">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">LinkedIn</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500">
             {isLoading ? 'Checking…' : status?.connected ? `Connected as ${status.username}` : 'Not connected'}
           </p>
         </div>
@@ -74,7 +74,7 @@ function LinkedInCard() {
         <button
           onClick={() => disconnect.mutate()}
           disabled={disconnect.isPending}
-          className="px-3 py-1.5 text-sm border border-red-200 text-red-600 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+          className="px-3 py-1.5 text-sm border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-950 transition-colors disabled:opacity-50"
         >
           {disconnect.isPending ? <Loader2 className="h-4 w-4 animate-spin inline" /> : 'Disconnect'}
         </button>
@@ -107,8 +107,8 @@ function MetaCard() {
             <Facebook className="h-5 w-5 text-white" />
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-900">Facebook Page</p>
-            <p className="text-xs text-gray-400">
+            <p className="text-sm font-medium text-gray-900 dark:text-white">Facebook Page</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500">
               {isLoading
                 ? 'Checking…'
                 : status?.facebook.connected
@@ -138,8 +138,8 @@ function MetaCard() {
             <Instagram className="h-5 w-5 text-white" />
           </div>
           <div>
-            <p className="text-sm font-medium text-gray-900">Instagram Business</p>
-            <p className="text-xs text-gray-400">
+            <p className="text-sm font-medium text-gray-900 dark:text-white">Instagram Business</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500">
               {isLoading
                 ? 'Checking…'
                 : status?.instagram.connected
@@ -157,7 +157,7 @@ function MetaCard() {
           <button
             onClick={() => disconnect.mutate()}
             disabled={disconnect.isPending}
-            className="px-3 py-1.5 text-sm border border-red-200 text-red-600 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+            className="px-3 py-1.5 text-sm border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-950 transition-colors disabled:opacity-50"
           >
             {disconnect.isPending ? (
               <Loader2 className="h-4 w-4 animate-spin inline" />
@@ -207,7 +207,7 @@ export default function SettingsPage() {
 
   if (isLoading)
     return (
-      <div className="flex items-center gap-2 text-gray-400 py-12 justify-center">
+      <div className="flex items-center gap-2 text-gray-400 dark:text-gray-500 py-12 justify-center">
         <Loader2 className="h-5 w-5 animate-spin" />
       </div>
     )
@@ -215,8 +215,8 @@ export default function SettingsPage() {
   return (
     <div className="space-y-8 max-w-2xl">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
-        <p className="text-gray-500 mt-1">Personalise your default caption preferences.</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Settings</h1>
+        <p className="text-gray-500 dark:text-gray-400 mt-1">Personalise your default caption preferences.</p>
       </div>
 
       <Suspense fallback={null}>
@@ -224,17 +224,17 @@ export default function SettingsPage() {
         <MetaBanner />
       </Suspense>
 
-      <div className="bg-white rounded-2xl border border-gray-200 p-6 space-y-6">
-        <h2 className="font-semibold text-gray-900">Connected Accounts</h2>
+      <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-6">
+        <h2 className="font-semibold text-gray-900 dark:text-white">Connected Accounts</h2>
         <LinkedInCard />
-        <div className="border-t border-gray-100 pt-4">
+        <div className="border-t border-gray-100 dark:border-gray-800 pt-4">
           <MetaCard />
         </div>
       </div>
 
       {mlProfile && (
-        <div className="bg-violet-50 border border-violet-200 rounded-xl p-5">
-          <h2 className="font-semibold text-violet-900 mb-3">Your AI Profile</h2>
+        <div className="bg-violet-50 dark:bg-violet-950 border border-violet-200 dark:border-violet-800 rounded-xl p-5">
+          <h2 className="font-semibold text-violet-900 dark:text-violet-300 mb-3">Your AI Profile</h2>
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
             <Stat label="Predicted tone" value={mlProfile.predictedTone} />
             <Stat label="Predicted language" value={mlProfile.predictedLanguage} />
@@ -244,13 +244,13 @@ export default function SettingsPage() {
         </div>
       )}
 
-      <div className="bg-white rounded-2xl border border-gray-200 p-6 space-y-6">
+      <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-6">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">Default language</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Default language</label>
           <select
             value={lang}
             onChange={(e) => setLang(e.target.value as Language)}
-            className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500"
           >
             {LANGUAGES.map((l) => (
               <option key={l.value} value={l.value}>
@@ -261,7 +261,7 @@ export default function SettingsPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">Default tone</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Default tone</label>
           <div className="flex flex-wrap gap-2">
             {TONES.map((t) => (
               <button
@@ -270,7 +270,7 @@ export default function SettingsPage() {
                 className={`px-3 py-1.5 rounded-full text-sm border transition-colors ${
                   tone === t.value
                     ? 'bg-violet-600 text-white border-violet-600'
-                    : 'border-gray-200 text-gray-600 hover:border-violet-300'
+                    : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-violet-300'
                 }`}
               >
                 {t.label}
@@ -280,7 +280,7 @@ export default function SettingsPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">Emoji usage</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Emoji usage</label>
           <div className="flex gap-2">
             {(['low', 'medium', 'high'] as EmojiUsage[]).map((level) => (
               <button
@@ -289,7 +289,7 @@ export default function SettingsPage() {
                 className={`flex-1 py-2 rounded-lg text-sm border capitalize transition-colors ${
                   emoji === level
                     ? 'bg-violet-600 text-white border-violet-600'
-                    : 'border-gray-200 text-gray-600 hover:border-violet-300'
+                    : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-violet-300'
                 }`}
               >
                 {level}
@@ -299,7 +299,7 @@ export default function SettingsPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">Preferred platforms</label>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Preferred platforms</label>
           <div className="flex flex-wrap gap-2">
             {PLATFORMS.map((p) => (
               <button
@@ -308,7 +308,7 @@ export default function SettingsPage() {
                 className={`px-3 py-1.5 rounded-full text-sm border transition-colors ${
                   platforms.includes(p.value as Platform)
                     ? 'bg-violet-600 text-white border-violet-600'
-                    : 'border-gray-200 text-gray-600 hover:border-violet-300'
+                    : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-violet-300'
                 }`}
               >
                 {p.label}
@@ -333,8 +333,8 @@ export default function SettingsPage() {
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <p className="text-xs text-violet-600 font-medium uppercase tracking-wide">{label}</p>
-      <p className="text-gray-900 font-semibold capitalize mt-0.5">{value}</p>
+      <p className="text-xs text-violet-600 dark:text-violet-400 font-medium uppercase tracking-wide">{label}</p>
+      <p className="text-gray-900 dark:text-violet-200 font-semibold capitalize mt-0.5">{value}</p>
     </div>
   )
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -26,17 +26,17 @@ const features = [
 
 export default function LandingPage() {
   return (
-    <main className="min-h-screen bg-gradient-to-br from-violet-50 via-white to-indigo-50">
+    <main className="min-h-screen bg-gradient-to-br from-violet-50 via-white to-indigo-50 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
       {/* Nav */}
       <nav className="flex items-center justify-between px-6 py-4 max-w-6xl mx-auto">
         <div className="flex items-center gap-2">
           <Sparkles className="h-6 w-6 text-violet-600" />
-          <span className="font-bold text-xl text-gray-900">SocialCraft AI</span>
+          <span className="font-bold text-xl text-gray-900 dark:text-white">SocialCraft AI</span>
         </div>
         <div className="flex gap-3">
           <Link
             href="/login"
-            className="px-4 py-2 text-sm font-medium text-gray-700 hover:text-violet-600 transition-colors"
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-violet-600 transition-colors"
           >
             Log in
           </Link>
@@ -51,26 +51,26 @@ export default function LandingPage() {
 
       {/* Hero */}
       <section className="text-center px-6 py-24 max-w-4xl mx-auto">
-        <span className="inline-block px-3 py-1 text-xs font-semibold bg-violet-100 text-violet-700 rounded-full mb-6 uppercase tracking-wide">
+        <span className="inline-block px-3 py-1 text-xs font-semibold bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-400 rounded-full mb-6 uppercase tracking-wide">
           AI-Powered · Multilingual · Self-Learning
         </span>
-        <h1 className="text-5xl sm:text-6xl font-extrabold text-gray-900 leading-tight mb-6">
+        <h1 className="text-5xl sm:text-6xl font-extrabold text-gray-900 dark:text-white leading-tight mb-6">
           Captions that speak{' '}
           <span className="text-transparent bg-clip-text bg-gradient-to-r from-violet-600 to-indigo-500">
             your language
           </span>
         </h1>
-        <p className="text-xl text-gray-600 mb-10 max-w-2xl mx-auto">
+        <p className="text-xl text-gray-600 dark:text-gray-400 mb-10 max-w-2xl mx-auto">
           Generate viral social media captions in 7 languages with AI that learns your style — so
           every post sounds authentically <em>you</em>.
         </p>
         <Link
           href="/signup"
-          className="inline-flex items-center gap-2 px-8 py-4 bg-violet-600 text-white font-semibold rounded-xl hover:bg-violet-700 transition-colors text-lg shadow-lg shadow-violet-200"
+          className="inline-flex items-center gap-2 px-8 py-4 bg-violet-600 text-white font-semibold rounded-xl hover:bg-violet-700 transition-colors text-lg shadow-lg shadow-violet-200 dark:shadow-violet-900"
         >
           Start generating free <ArrowRight className="h-5 w-5" />
         </Link>
-        <p className="mt-4 text-sm text-gray-500">No credit card · 10 captions/day free</p>
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-500">No credit card · 10 captions/day free</p>
       </section>
 
       {/* Features */}
@@ -79,20 +79,20 @@ export default function LandingPage() {
           {features.map(({ icon: Icon, title, description }) => (
             <div
               key={title}
-              className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100 hover:shadow-md transition-shadow"
+              className="bg-white dark:bg-gray-900 rounded-2xl p-6 shadow-sm border border-gray-100 dark:border-gray-700 hover:shadow-md transition-shadow"
             >
-              <div className="w-10 h-10 bg-violet-100 rounded-xl flex items-center justify-center mb-4">
-                <Icon className="h-5 w-5 text-violet-600" />
+              <div className="w-10 h-10 bg-violet-100 dark:bg-violet-950 rounded-xl flex items-center justify-center mb-4">
+                <Icon className="h-5 w-5 text-violet-600 dark:text-violet-400" />
               </div>
-              <h3 className="font-semibold text-gray-900 mb-2">{title}</h3>
-              <p className="text-sm text-gray-600">{description}</p>
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-2">{title}</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
             </div>
           ))}
         </div>
       </section>
 
       {/* Footer */}
-      <footer className="text-center py-8 text-sm text-gray-400 border-t border-gray-100">
+      <footer className="text-center py-8 text-sm text-gray-400 dark:text-gray-600 border-t border-gray-100 dark:border-gray-800">
         © {new Date().getFullYear()} SocialCraft AI. Built with Claude AI.
       </footer>
     </main>

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState } from 'react'
+import { ThemeProvider } from 'next-themes'
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -13,5 +14,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
       }),
   )
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </ThemeProvider>
+  )
 }

--- a/frontend/components/caption/CaptionCard.tsx
+++ b/frontend/components/caption/CaptionCard.tsx
@@ -68,47 +68,47 @@ export function CaptionCard({ caption, showFeedback = true }: Props) {
   }
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 p-5 space-y-4 hover:shadow-sm transition-shadow">
+    <div className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-5 space-y-4 hover:shadow-sm transition-shadow">
       <div className="flex flex-wrap items-center gap-2 text-xs">
-        <span className="px-2 py-1 bg-violet-100 text-violet-700 rounded-full font-medium capitalize">
+        <span className="px-2 py-1 bg-violet-100 dark:bg-violet-950 text-violet-700 dark:text-violet-400 rounded-full font-medium capitalize">
           {caption.language}
         </span>
-        <span className="px-2 py-1 bg-gray-100 text-gray-600 rounded-full capitalize">
+        <span className="px-2 py-1 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full capitalize">
           {caption.tone}
         </span>
-        <span className="px-2 py-1 bg-gray-100 text-gray-600 rounded-full capitalize">
+        <span className="px-2 py-1 bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded-full capitalize">
           {caption.platform}
         </span>
-        <span className="ml-auto text-gray-400">{formatDate(caption.createdAt)}</span>
+        <span className="ml-auto text-gray-400 dark:text-gray-500">{formatDate(caption.createdAt)}</span>
       </div>
 
-      <p className="text-gray-800 whitespace-pre-wrap text-sm leading-relaxed">
+      <p className="text-gray-800 dark:text-gray-100 whitespace-pre-wrap text-sm leading-relaxed">
         {caption.finalText ?? caption.generatedText}
       </p>
 
       {caption.hashtags.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {caption.hashtags.map((tag) => (
-            <span key={tag} className="text-xs text-violet-600 bg-violet-50 px-2 py-0.5 rounded">
+            <span key={tag} className="text-xs text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-950 px-2 py-0.5 rounded">
               {tag.startsWith('#') ? tag : `#${tag}`}
             </span>
           ))}
         </div>
       )}
 
-      <p className="text-xs text-gray-400">
+      <p className="text-xs text-gray-400 dark:text-gray-500">
         Topic: <span className="italic">{caption.topic}</span>
       </p>
 
       {(metaStatus?.facebook.connected || metaStatus?.instagram.connected) && (
-        <div className="border-t border-gray-100 pt-3 space-y-2">
+        <div className="border-t border-gray-100 dark:border-gray-800 pt-3 space-y-2">
           <ImageUpload
             url={imageUrl}
             onUpload={setImageUrl}
             onRemove={() => { setImageUrl(''); setIgMissingImage(false) }}
           />
           {igMissingImage && (
-            <p className="text-xs text-amber-600">A photo is required for Instagram.</p>
+            <p className="text-xs text-amber-600 dark:text-amber-400">A photo is required for Instagram.</p>
           )}
         </div>
       )}
@@ -119,7 +119,7 @@ export function CaptionCard({ caption, showFeedback = true }: Props) {
         <div className="flex items-center gap-2 ml-auto flex-wrap">
           <button
             onClick={() => router.push('/dashboard/scheduler')}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs border border-gray-200 text-gray-600 rounded-lg hover:border-violet-300 hover:text-violet-600 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 rounded-lg hover:border-violet-300 hover:text-violet-600 dark:hover:border-violet-600 dark:hover:text-violet-400 transition-colors"
           >
             <CalendarClock className="h-3 w-3" />
             Schedule
@@ -127,12 +127,12 @@ export function CaptionCard({ caption, showFeedback = true }: Props) {
 
           {linkedInStatus?.connected && (
             published ? (
-              <div className="flex items-center gap-1.5 text-xs text-green-600 font-medium">
+              <div className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400 font-medium">
                 <CheckCircle2 className="h-3.5 w-3.5" />
                 Posted to LinkedIn
               </div>
             ) : publish.isError ? (
-              <span className="text-xs text-red-500">LinkedIn failed — try again</span>
+              <span className="text-xs text-red-500 dark:text-red-400">LinkedIn failed — try again</span>
             ) : (
               <button
                 onClick={handlePublish}
@@ -147,12 +147,12 @@ export function CaptionCard({ caption, showFeedback = true }: Props) {
 
           {metaStatus?.facebook.connected && (
             fbPublished ? (
-              <div className="flex items-center gap-1.5 text-xs text-green-600 font-medium">
+              <div className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400 font-medium">
                 <CheckCircle2 className="h-3.5 w-3.5" />
                 Posted to Facebook
               </div>
             ) : publishFb.isError ? (
-              <span className="text-xs text-red-500">Facebook failed — try again</span>
+              <span className="text-xs text-red-500 dark:text-red-400">Facebook failed — try again</span>
             ) : (
               <button
                 onClick={handlePublishFacebook}
@@ -167,12 +167,12 @@ export function CaptionCard({ caption, showFeedback = true }: Props) {
 
           {metaStatus?.instagram.connected && (
             igPublished ? (
-              <div className="flex items-center gap-1.5 text-xs text-green-600 font-medium">
+              <div className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400 font-medium">
                 <CheckCircle2 className="h-3.5 w-3.5" />
                 Posted to Instagram
               </div>
             ) : publishIg.isError ? (
-              <span className="text-xs text-red-500">Instagram failed — try again</span>
+              <span className="text-xs text-red-500 dark:text-red-400">Instagram failed — try again</span>
             ) : (
               <button
                 onClick={handlePublishInstagram}

--- a/frontend/components/caption/CaptionGenerator.tsx
+++ b/frontend/components/caption/CaptionGenerator.tsx
@@ -33,14 +33,12 @@ export function CaptionGenerator() {
 
   return (
     <div className="space-y-6">
-      {/* Form */}
       <form
         onSubmit={handleSubmit}
-        className="bg-white rounded-2xl border border-gray-200 p-6 space-y-6"
+        className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-6"
       >
-        {/* Topic */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             What&apos;s your post about?
           </label>
           <textarea
@@ -48,7 +46,7 @@ export function CaptionGenerator() {
             onChange={(e) => setTopic(e.target.value)}
             rows={3}
             placeholder="e.g. Launching my new fitness app that tracks calories using AI..."
-            className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none placeholder:text-gray-400"
+            className="w-full border border-gray-200 dark:border-gray-600 rounded-xl px-4 py-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none"
           />
           {validationError && (
             <p className="mt-1 text-xs text-red-500 flex items-center gap-1">
@@ -78,26 +76,23 @@ export function CaptionGenerator() {
         </button>
       </form>
 
-      {/* Error */}
       {generate.isError && (
-        <div className="flex items-center gap-2 bg-red-50 border border-red-200 text-red-700 rounded-xl px-4 py-3 text-sm">
+        <div className="flex items-center gap-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 rounded-xl px-4 py-3 text-sm">
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {generate.error?.message ?? 'Failed to generate captions. Please try again.'}
         </div>
       )}
 
-      {/* Personalization badge */}
       {personalizationUsed && captions.length > 0 && (
-        <div className="flex items-center gap-2 bg-violet-50 border border-violet-200 text-violet-700 rounded-xl px-4 py-3 text-sm">
+        <div className="flex items-center gap-2 bg-violet-50 dark:bg-violet-950 border border-violet-200 dark:border-violet-800 text-violet-700 dark:text-violet-400 rounded-xl px-4 py-3 text-sm">
           <Brain className="h-4 w-4 flex-shrink-0" />
           Personalized to your style — confidence {Math.round(confidenceScore * 100)}%
         </div>
       )}
 
-      {/* Results */}
       {captions.length > 0 && (
         <div className="space-y-4">
-          <h2 className="font-semibold text-gray-900">
+          <h2 className="font-semibold text-gray-900 dark:text-white">
             {captions.length} caption{captions.length > 1 ? 's' : ''} generated
           </h2>
           {captions.map((caption) => (

--- a/frontend/components/caption/FeedbackButtons.tsx
+++ b/frontend/components/caption/FeedbackButtons.tsx
@@ -52,7 +52,7 @@ export function FeedbackButtons({ caption }: Props) {
             value={editText}
             onChange={(e) => setEditText(e.target.value)}
             rows={4}
-            className="w-full border border-violet-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none"
+            className="w-full border border-violet-300 dark:border-violet-700 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none"
           />
           <div className="flex gap-2">
             <button
@@ -64,7 +64,7 @@ export function FeedbackButtons({ caption }: Props) {
             </button>
             <button
               onClick={() => setEditing(false)}
-              className="px-3 py-1.5 border border-gray-200 text-gray-600 rounded-lg text-xs hover:bg-gray-50 transition-colors"
+              className="px-3 py-1.5 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 rounded-lg text-xs hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
             >
               Cancel
             </button>
@@ -79,8 +79,8 @@ export function FeedbackButtons({ caption }: Props) {
           title="Like"
           className={`p-2 rounded-lg border transition-colors ${
             liked
-              ? 'bg-green-50 border-green-400 text-green-600'
-              : 'border-gray-200 text-gray-500 hover:border-green-400 hover:text-green-600'
+              ? 'bg-green-50 dark:bg-green-950 border-green-400 text-green-600'
+              : 'border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-green-400 hover:text-green-600'
           }`}
         >
           <ThumbsUp className="h-4 w-4" />
@@ -91,8 +91,8 @@ export function FeedbackButtons({ caption }: Props) {
           title="Dislike"
           className={`p-2 rounded-lg border transition-colors ${
             disliked
-              ? 'bg-red-50 border-red-400 text-red-600'
-              : 'border-gray-200 text-gray-500 hover:border-red-400 hover:text-red-600'
+              ? 'bg-red-50 dark:bg-red-950 border-red-400 text-red-600'
+              : 'border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-red-400 hover:text-red-600'
           }`}
         >
           <ThumbsDown className="h-4 w-4" />
@@ -100,14 +100,14 @@ export function FeedbackButtons({ caption }: Props) {
         <button
           onClick={() => setEditing((v) => !v)}
           title="Edit"
-          className="p-2 rounded-lg border border-gray-200 text-gray-500 hover:border-blue-400 hover:text-blue-600 transition-colors"
+          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 hover:border-blue-400 hover:text-blue-600 transition-colors"
         >
           <Pencil className="h-4 w-4" />
         </button>
         <button
           onClick={handleCopy}
           title="Copy"
-          className="ml-auto flex items-center gap-1.5 px-3 py-2 rounded-lg border border-gray-200 text-sm text-gray-600 hover:bg-gray-50 transition-colors"
+          className="ml-auto flex items-center gap-1.5 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
         >
           {copied ? (
             <>

--- a/frontend/components/caption/LanguageSelector.tsx
+++ b/frontend/components/caption/LanguageSelector.tsx
@@ -12,7 +12,7 @@ interface Props {
 export function LanguageSelector({ value, onChange }: Props) {
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-2">Language</label>
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Language</label>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         {LANGUAGES.map((lang) => (
           <button
@@ -22,8 +22,8 @@ export function LanguageSelector({ value, onChange }: Props) {
             className={cn(
               'flex items-center gap-2 px-3 py-2.5 rounded-lg border text-sm transition-colors text-left',
               value === lang.value
-                ? 'border-violet-500 bg-violet-50 text-violet-700 font-medium'
-                : 'border-gray-200 text-gray-600 hover:border-violet-300 hover:bg-violet-50/40',
+                ? 'border-violet-500 bg-violet-50 dark:bg-violet-950 text-violet-700 dark:text-violet-400 font-medium'
+                : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-violet-300 hover:bg-violet-50/40 dark:hover:bg-violet-950/40',
             )}
           >
             <span className="text-base">{lang.flag}</span>

--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -4,28 +4,30 @@ import Link from 'next/link'
 import { Sparkles, LogOut, User } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useUserStore } from '@/store/userStore'
+import { ThemeToggle } from '@/components/ui/ThemeToggle'
 
 export function Navbar() {
   const { signOut } = useAuth()
   const { user } = useUserStore()
 
   return (
-    <header className="h-14 bg-white border-b border-gray-200 flex items-center px-6 sticky top-0 z-30">
-      <Link href="/dashboard" className="flex items-center gap-2 font-bold text-gray-900 mr-auto">
+    <header className="h-14 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 flex items-center px-6 sticky top-0 z-30">
+      <Link href="/dashboard" className="flex items-center gap-2 font-bold text-gray-900 dark:text-white mr-auto">
         <Sparkles className="h-5 w-5 text-violet-600" />
         SocialCraft AI
       </Link>
 
       <div className="flex items-center gap-3">
         {user && (
-          <span className="hidden sm:flex items-center gap-2 text-sm text-gray-600">
+          <span className="hidden sm:flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
             <User className="h-4 w-4" />
             {user.email}
           </span>
         )}
+        <ThemeToggle />
         <button
           onClick={signOut}
-          className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-red-500 transition-colors"
+          className="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors"
         >
           <LogOut className="h-4 w-4" />
           <span className="hidden sm:inline">Sign out</span>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -6,18 +6,18 @@ import { Sparkles, History, CalendarClock, BarChart3, Settings } from 'lucide-re
 import { cn } from '@/lib/utils'
 
 const links = [
-  { href: '/dashboard',           icon: Sparkles,     label: 'Generate' },
-  { href: '/dashboard/history',   icon: History,      label: 'History' },
+  { href: '/dashboard',           icon: Sparkles,      label: 'Generate' },
+  { href: '/dashboard/history',   icon: History,       label: 'History' },
   { href: '/dashboard/scheduler', icon: CalendarClock, label: 'Scheduler' },
-  { href: '/dashboard/analytics',  icon: BarChart3,     label: 'Analytics' },
-  { href: '/dashboard/settings',   icon: Settings,      label: 'Settings' },
+  { href: '/dashboard/analytics', icon: BarChart3,     label: 'Analytics' },
+  { href: '/dashboard/settings',  icon: Settings,      label: 'Settings' },
 ]
 
 export function Sidebar() {
   const pathname = usePathname()
 
   return (
-    <aside className="hidden md:flex flex-col w-56 min-h-[calc(100vh-3.5rem)] bg-white border-r border-gray-200 py-6 px-3 sticky top-14">
+    <aside className="hidden md:flex flex-col w-56 min-h-[calc(100vh-3.5rem)] bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 py-6 px-3 sticky top-14">
       <nav className="space-y-1">
         {links.map(({ href, icon: Icon, label }) => {
           const active = pathname === href
@@ -28,8 +28,8 @@ export function Sidebar() {
               className={cn(
                 'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors',
                 active
-                  ? 'bg-violet-50 text-violet-700'
-                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900',
+                  ? 'bg-violet-50 dark:bg-violet-950 text-violet-700 dark:text-violet-400'
+                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-white',
               )}
             >
               <Icon className="h-4 w-4 flex-shrink-0" />

--- a/frontend/components/shared/PlatformSelector.tsx
+++ b/frontend/components/shared/PlatformSelector.tsx
@@ -21,7 +21,7 @@ const PLATFORM_ICONS: Record<string, string> = {
 export function PlatformSelector({ value, onChange }: Props) {
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-2">Platform</label>
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Platform</label>
       <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
         {PLATFORMS.map((p) => (
           <button
@@ -31,8 +31,8 @@ export function PlatformSelector({ value, onChange }: Props) {
             className={cn(
               'flex flex-col items-center gap-1 py-3 rounded-xl border text-xs font-medium transition-colors',
               value === p.value
-                ? 'border-violet-500 bg-violet-50 text-violet-700'
-                : 'border-gray-200 text-gray-600 hover:border-violet-300 hover:bg-violet-50/30',
+                ? 'border-violet-500 bg-violet-50 dark:bg-violet-950 text-violet-700 dark:text-violet-400'
+                : 'border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-violet-300 hover:bg-violet-50/30 dark:hover:bg-violet-950/30',
               !p.free && 'opacity-60 cursor-not-allowed',
             )}
             disabled={!p.free}
@@ -41,7 +41,7 @@ export function PlatformSelector({ value, onChange }: Props) {
             <span className="text-xl">{PLATFORM_ICONS[p.value]}</span>
             <span>{p.label}</span>
             {!p.free && (
-              <span className="text-[10px] text-gray-400 leading-none">soon</span>
+              <span className="text-[10px] text-gray-400 dark:text-gray-500 leading-none">soon</span>
             )}
           </button>
         ))}

--- a/frontend/components/shared/ToneSelector.tsx
+++ b/frontend/components/shared/ToneSelector.tsx
@@ -12,7 +12,7 @@ interface Props {
 export function ToneSelector({ value, onChange }: Props) {
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-2">Tone</label>
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Tone</label>
       <div className="flex flex-wrap gap-2">
         {TONES.map((tone) => (
           <button
@@ -23,7 +23,7 @@ export function ToneSelector({ value, onChange }: Props) {
               'px-4 py-2 rounded-full border text-sm font-medium transition-colors',
               value === tone.value
                 ? 'border-violet-600 bg-violet-600 text-white'
-                : `border ${TONE_COLORS[tone.color]} border-current`,
+                : `border ${TONE_COLORS[tone.color]} border-current dark:opacity-80`,
             )}
           >
             {tone.label}

--- a/frontend/components/ui/ThemeToggle.tsx
+++ b/frontend/components/ui/ThemeToggle.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { Moon, Sun } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      title="Toggle theme"
+      className="p-2 rounded-lg text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+    >
+      {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  )
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.379.0",
         "next": "14.2.3",
+        "next-themes": "^0.4.6",
         "react": "^18",
         "react-dom": "^18",
         "recharts": "^3.8.1",
@@ -6291,6 +6292,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.379.0",
     "next": "14.2.3",
+    "next-themes": "^0.4.6",
     "react": "^18",
     "react-dom": "^18",
     "recharts": "^3.8.1",


### PR DESCRIPTION
Closes #89

## Summary
- Installs \
ext-themes\ and wraps the app in \ThemeProvider\ with \defaultTheme: system\
- Adds a Sun/Moon \ThemeToggle\ button to the Navbar
- Applies \dark:\ Tailwind variants across all 16 frontend components and pages

## What's covered
- **Layout**: Navbar, Sidebar, dashboard shell, loading state
- **Caption flow**: CaptionGenerator, CaptionCard, FeedbackButtons, LanguageSelector, ToneSelector, PlatformSelector
- **Pages**: Generate, History, Settings (preferences + social accounts), Scheduler (form + post cards), Analytics (stat cards + all 4 charts), Landing page
- **Inputs/selects/textareas**: dark backgrounds and borders on all form elements
- **Theme persistence**: stored in localStorage; follows OS dark/light preference on first visit