### PR TITLE
feat(captions): image-to-caption using Claude vision API

### DIFF
--- a/backend/app/models/caption.py
+++ b/backend/app/models/caption.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from typing import Literal, Optional
 from datetime import datetime
 import uuid
@@ -10,11 +10,19 @@ Platform = Literal["instagram", "facebook", "youtube", "linkedin", "threads", "p
 
 
 class GenerateCaptionRequest(BaseModel):
-    topic: str = Field(..., min_length=3, max_length=500)
+    topic: Optional[str] = Field(default=None, max_length=500)
+    image_base64: Optional[str] = None
+    image_media_type: Optional[str] = Field(default=None, pattern=r"^image/(jpeg|png|gif|webp)$")
     language: Language
     tone: Tone
     platform: Platform
     count: int = Field(default=3, ge=1, le=5)
+
+    @model_validator(mode="after")
+    def topic_or_image_required(self) -> GenerateCaptionRequest:
+        if not self.topic and not self.image_base64:
+            raise ValueError("Provide either a topic or an image.")
+        return self
 
 
 class CaptionItem(BaseModel):

--- a/backend/app/routers/captions.py
+++ b/backend/app/routers/captions.py
@@ -40,17 +40,20 @@ async def generate_captions(
 
         # Build user profile for personalization
         user_profile = await personalization.build_user_profile(user_id)
-        similar_captions = await personalization.get_similar_liked_captions(user_id, req.topic)
+        topic = req.topic or "📷 Photo"
+        similar_captions = await personalization.get_similar_liked_captions(user_id, topic)
 
         # Generate via Claude
         raw_captions = await claude.generate(
-            topic=req.topic,
+            topic=topic,
             language=req.language,
             tone=req.tone,
             platform=req.platform,
             count=req.count,
             user_profile=user_profile,
             similar_captions=similar_captions,
+            image_base64=req.image_base64,
+            image_media_type=req.image_media_type,
         )
 
         personalization_used = bool(user_profile.get("data_points", 0) >= 3)
@@ -68,7 +71,7 @@ async def generate_captions(
             rows.append({
                 "id": caption_id,
                 "user_id": user_id,
-                "topic": req.topic,
+                "topic": topic,
                 "generated_text": cap["text"],
                 "language": req.language,
                 "tone": req.tone,
@@ -77,11 +80,11 @@ async def generate_captions(
                 "created_at": now,
             })
             caption_ids_for_embedding.append(caption_id)
-            texts_for_embedding.append(f"{req.topic} {cap['text']}")
+            texts_for_embedding.append(f"{topic} {cap['text']}")
             items.append(
                 CaptionItem(
                     id=caption_id,
-                    topic=req.topic,
+                    topic=topic,
                     generated_text=cap["text"],
                     language=req.language,
                     tone=req.tone,

--- a/backend/app/services/claude_service.py
+++ b/backend/app/services/claude_service.py
@@ -52,23 +52,40 @@ class ClaudeService:
         count: int,
         user_profile: dict,
         similar_captions: list[str],
+        image_base64: str | None = None,
+        image_media_type: str | None = None,
     ) -> list[dict]:
         effective_profile = {**user_profile, "preferred_language": language, "preferred_tone": tone}
         system = build_system_prompt(effective_profile, similar_captions)
-        user_message = (
-            f"Generate {count} {tone} {language} captions for {platform} about: {topic}"
-        )
+
+        if topic:
+            user_text = f"Generate {count} {tone} {language} captions for {platform} about: {topic}"
+        else:
+            user_text = f"Generate {count} {tone} {language} captions for {platform} based on this image."
+
+        if image_base64 and image_media_type:
+            content: list = [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": image_media_type,
+                        "data": image_base64,
+                    },
+                },
+                {"type": "text", "text": user_text},
+            ]
+        else:
+            content = user_text
 
         message = self._client.messages.create(
             model="claude-sonnet-4-6",
             max_tokens=2048,
             system=system,
-            messages=[{"role": "user", "content": user_message}],
+            messages=[{"role": "user", "content": content}],
         )
 
         raw = message.content[0].text.strip()
-
-        # Strip markdown fences if Claude adds them despite instructions
         raw = re.sub(r"^```(?:json)?\s*", "", raw)
         raw = re.sub(r"\s*```$", "", raw)
 

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { Sparkles, Loader2 } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
+import { ThemeToggle } from '@/components/ui/ThemeToggle'
 
 export default function LoginPage() {
   const { signInWithEmail, signInWithGoogle } = useAuth()
@@ -26,76 +27,65 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-violet-50 to-indigo-50 flex items-center justify-center p-4">
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
-        {/* Logo */}
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 to-indigo-50 dark:from-gray-950 dark:to-gray-900 flex items-center justify-center p-4 relative">
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
+
+      <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-8 border border-gray-100 dark:border-gray-700">
         <div className="flex items-center gap-2 justify-center mb-8">
           <Sparkles className="h-6 w-6 text-violet-600" />
-          <span className="font-bold text-xl text-gray-900">SocialCraft AI</span>
+          <span className="font-bold text-xl text-gray-900 dark:text-white">SocialCraft AI</span>
         </div>
 
-        <h1 className="text-2xl font-bold text-gray-900 text-center mb-2">Welcome back</h1>
-        <p className="text-gray-500 text-center text-sm mb-8">Sign in to your account</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white text-center mb-2">Welcome back</h1>
+        <p className="text-gray-500 dark:text-gray-400 text-center text-sm mb-8">Sign in to your account</p>
 
         {error && (
-          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3 mb-6">
+          <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 text-sm rounded-lg px-4 py-3 mb-6">
             {error}
           </div>
         )}
 
-        {/* Google */}
         <button
           onClick={signInWithGoogle}
-          className="w-full flex items-center justify-center gap-3 border border-gray-200 rounded-lg py-3 px-4 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors mb-6"
+          className="w-full flex items-center justify-center gap-3 border border-gray-200 dark:border-gray-700 rounded-lg py-3 px-4 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors mb-6"
         >
           <svg className="h-4 w-4" viewBox="0 0 24 24">
-            <path
-              fill="#4285F4"
-              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-            />
-            <path
-              fill="#34A853"
-              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-            />
-            <path
-              fill="#FBBC05"
-              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-            />
-            <path
-              fill="#EA4335"
-              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-            />
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
           </svg>
           Continue with Google
         </button>
 
         <div className="flex items-center gap-3 mb-6">
-          <div className="flex-1 h-px bg-gray-200" />
-          <span className="text-xs text-gray-400">or</span>
-          <div className="flex-1 h-px bg-gray-200" />
+          <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+          <span className="text-xs text-gray-400 dark:text-gray-500">or</span>
+          <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
         </div>
 
-        {/* Email form */}
         <form onSubmit={handleEmail} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email</label>
             <input
               type="email"
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+              className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500"
               placeholder="you@example.com"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Password</label>
             <input
               type="password"
               required
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+              className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500"
               placeholder="••••••••"
             />
           </div>
@@ -109,7 +99,7 @@ export default function LoginPage() {
           </button>
         </form>
 
-        <p className="text-center text-sm text-gray-500 mt-6">
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-6">
           Don&apos;t have an account?{' '}
           <Link href="/signup" className="text-violet-600 hover:text-violet-700 font-medium">
             Sign up

--- a/frontend/app/(auth)/signup/page.tsx
+++ b/frontend/app/(auth)/signup/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { Sparkles, Loader2, CheckCircle } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
+import { ThemeToggle } from '@/components/ui/ThemeToggle'
 
 export default function SignupPage() {
   const { signUpWithEmail, signInWithGoogle } = useAuth()
@@ -29,13 +30,15 @@ export default function SignupPage() {
 
   if (done) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-violet-50 to-indigo-50 flex items-center justify-center p-4">
-        <div className="text-center bg-white rounded-2xl shadow-xl p-10 border border-gray-100 max-w-sm w-full">
+      <div className="min-h-screen bg-gradient-to-br from-violet-50 to-indigo-50 dark:from-gray-950 dark:to-gray-900 flex items-center justify-center p-4 relative">
+        <div className="absolute top-4 right-4">
+          <ThemeToggle />
+        </div>
+        <div className="text-center bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-10 border border-gray-100 dark:border-gray-700 max-w-sm w-full">
           <CheckCircle className="h-12 w-12 text-green-500 mx-auto mb-4" />
-          <h2 className="text-xl font-bold text-gray-900 mb-2">Check your email</h2>
-          <p className="text-gray-500 text-sm">
-            We sent a confirmation link to <strong>{email}</strong>. Click it to activate your
-            account.
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">Check your email</h2>
+          <p className="text-gray-500 dark:text-gray-400 text-sm">
+            We sent a confirmation link to <strong>{email}</strong>. Click it to activate your account.
           </p>
           <Link
             href="/login"
@@ -49,25 +52,29 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-violet-50 to-indigo-50 flex items-center justify-center p-4">
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 border border-gray-100">
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 to-indigo-50 dark:from-gray-950 dark:to-gray-900 flex items-center justify-center p-4 relative">
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
+
+      <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-8 border border-gray-100 dark:border-gray-700">
         <div className="flex items-center gap-2 justify-center mb-8">
           <Sparkles className="h-6 w-6 text-violet-600" />
-          <span className="font-bold text-xl text-gray-900">SocialCraft AI</span>
+          <span className="font-bold text-xl text-gray-900 dark:text-white">SocialCraft AI</span>
         </div>
 
-        <h1 className="text-2xl font-bold text-gray-900 text-center mb-2">Create account</h1>
-        <p className="text-gray-500 text-center text-sm mb-8">10 captions/day — no card needed</p>
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white text-center mb-2">Create account</h1>
+        <p className="text-gray-500 dark:text-gray-400 text-center text-sm mb-8">10 captions/day — no card needed</p>
 
         {error && (
-          <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3 mb-6">
+          <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 text-sm rounded-lg px-4 py-3 mb-6">
             {error}
           </div>
         )}
 
         <button
           onClick={signInWithGoogle}
-          className="w-full flex items-center justify-center gap-3 border border-gray-200 rounded-lg py-3 px-4 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors mb-6"
+          className="w-full flex items-center justify-center gap-3 border border-gray-200 dark:border-gray-700 rounded-lg py-3 px-4 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors mb-6"
         >
           <svg className="h-4 w-4" viewBox="0 0 24 24">
             <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
@@ -79,26 +86,26 @@ export default function SignupPage() {
         </button>
 
         <div className="flex items-center gap-3 mb-6">
-          <div className="flex-1 h-px bg-gray-200" />
-          <span className="text-xs text-gray-400">or</span>
-          <div className="flex-1 h-px bg-gray-200" />
+          <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+          <span className="text-xs text-gray-400 dark:text-gray-500">or</span>
+          <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Email</label>
             <input
               type="email"
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+              className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500"
               placeholder="you@example.com"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Password <span className="text-gray-400 font-normal">(min 6 chars)</span>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Password <span className="text-gray-400 dark:text-gray-500 font-normal">(min 6 chars)</span>
             </label>
             <input
               type="password"
@@ -106,7 +113,7 @@ export default function SignupPage() {
               minLength={6}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500"
+              className="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500"
               placeholder="••••••••"
             />
           </div>
@@ -120,7 +127,7 @@ export default function SignupPage() {
           </button>
         </form>
 
-        <p className="text-center text-sm text-gray-500 mt-6">
+        <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-6">
           Already have an account?{' '}
           <Link href="/login" className="text-violet-600 hover:text-violet-700 font-medium">
             Sign in

--- a/frontend/app/auth/callback/route.ts
+++ b/frontend/app/auth/callback/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: NextRequest) {
       {
         cookies: {
           getAll() { return cookieStore.getAll() },
-          setAll(cookiesToSet) {
+          setAll(cookiesToSet: { name: string; value: string; options?: object }[]) {
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, options)
             )

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
+      <body className={inter.className} suppressHydrationWarning>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/frontend/components/caption/CaptionGenerator.tsx
+++ b/frontend/components/caption/CaptionGenerator.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { Loader2, Sparkles, AlertCircle, Brain } from 'lucide-react'
+import { useRef, useState } from 'react'
+import { Loader2, Sparkles, AlertCircle, Brain, ImagePlus, X } from 'lucide-react'
 import { useGenerateCaptions } from '@/hooks/useCaption'
 import { useCaptionStore } from '@/store/captionStore'
 import { LanguageSelector } from './LanguageSelector'
@@ -9,9 +9,12 @@ import { ToneSelector } from '@/components/shared/ToneSelector'
 import { PlatformSelector } from '@/components/shared/PlatformSelector'
 import { CaptionCard } from './CaptionCard'
 
+const MAX_IMAGE_BYTES = 4 * 1024 * 1024 // 4 MB — Claude's limit
+
 export function CaptionGenerator() {
   const {
     topic, setTopic,
+    imageBase64, imageMediaType, setImage, clearImage,
     language, setLanguage,
     tone, setTone,
     platform, setPlatform,
@@ -20,15 +23,53 @@ export function CaptionGenerator() {
 
   const generate = useGenerateCaptions()
   const [validationError, setValidationError] = useState('')
+  const [imagePreview, setImagePreview] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    if (file.size > MAX_IMAGE_BYTES) {
+      setValidationError('Image must be under 4 MB.')
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onload = () => {
+      const result = reader.result as string
+      // result is "data:image/jpeg;base64,XXXXX"
+      const [prefix, data] = result.split(',')
+      const mediaType = prefix.replace('data:', '').replace(';base64', '')
+      setImage(data, mediaType)
+      setImagePreview(result)
+      setValidationError('')
+    }
+    reader.readAsDataURL(file)
+  }
+
+  const handleRemoveImage = () => {
+    clearImage()
+    setImagePreview('')
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!topic.trim()) {
-      setValidationError('Please enter a topic.')
+    if (!topic.trim() && !imageBase64) {
+      setValidationError('Enter a topic or upload an image.')
       return
     }
     setValidationError('')
-    generate.mutate({ topic: topic.trim(), language, tone, platform, count: 3 })
+    generate.mutate({
+      topic: topic.trim() || undefined,
+      imageBase64: imageBase64 || undefined,
+      imageMediaType: imageMediaType || undefined,
+      language,
+      tone,
+      platform,
+      count: 3,
+    })
   }
 
   return (
@@ -37,15 +78,78 @@ export function CaptionGenerator() {
         onSubmit={handleSubmit}
         className="bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 space-y-6"
       >
+        {/* Image upload */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Upload image <span className="text-gray-400 dark:text-gray-500 font-normal">(optional)</span>
+            </label>
+            {!imagePreview && (
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="flex items-center gap-1.5 text-xs text-violet-600 dark:text-violet-400 hover:text-violet-700 transition-colors"
+              >
+                <ImagePlus className="h-3.5 w-3.5" />
+                Choose photo
+              </button>
+            )}
+          </div>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            onChange={handleImageChange}
+            className="hidden"
+          />
+
+          {imagePreview ? (
+            <div className="relative w-full rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={imagePreview}
+                alt="Upload preview"
+                className="w-full max-h-64 object-cover"
+              />
+              <button
+                type="button"
+                onClick={handleRemoveImage}
+                className="absolute top-2 right-2 p-1.5 bg-black/60 hover:bg-black/80 text-white rounded-full transition-colors"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center hover:border-violet-300 dark:hover:border-violet-600 transition-colors group"
+            >
+              <ImagePlus className="h-8 w-8 mx-auto text-gray-300 dark:text-gray-600 group-hover:text-violet-400 transition-colors mb-2" />
+              <p className="text-sm text-gray-400 dark:text-gray-500">
+                Drop a photo here or <span className="text-violet-600 dark:text-violet-400">browse</span>
+              </p>
+              <p className="text-xs text-gray-300 dark:text-gray-600 mt-1">JPEG, PNG, WebP · max 4 MB</p>
+            </button>
+          )}
+        </div>
+
+        {/* Topic */}
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            What&apos;s your post about?
+            {imagePreview ? 'Add context' : "What's your post about?"}
+            {imagePreview && <span className="text-gray-400 dark:text-gray-500 font-normal"> (optional)</span>}
           </label>
           <textarea
             value={topic}
             onChange={(e) => setTopic(e.target.value)}
-            rows={3}
-            placeholder="e.g. Launching my new fitness app that tracks calories using AI..."
+            rows={imagePreview ? 2 : 3}
+            placeholder={
+              imagePreview
+                ? 'e.g. My trip to Goa, summer vibes…'
+                : 'e.g. Launching my new fitness app that tracks calories using AI…'
+            }
             className="w-full border border-gray-200 dark:border-gray-600 rounded-xl px-4 py-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 resize-none"
           />
           {validationError && (
@@ -66,7 +170,8 @@ export function CaptionGenerator() {
         >
           {generate.isPending ? (
             <>
-              <Loader2 className="h-5 w-5 animate-spin" /> Generating…
+              <Loader2 className="h-5 w-5 animate-spin" />
+              {imageBase64 ? 'Analysing image…' : 'Generating…'}
             </>
           ) : (
             <>

--- a/frontend/hooks/useCaption.ts
+++ b/frontend/hooks/useCaption.ts
@@ -16,9 +16,18 @@ export function useGenerateCaptions() {
 
   return useMutation({
     mutationFn: async (payload: GenerateCaptionRequest) => {
+      const body = {
+        topic: payload.topic || undefined,
+        image_base64: payload.imageBase64 || undefined,
+        image_media_type: payload.imageMediaType || undefined,
+        language: payload.language,
+        tone: payload.tone,
+        platform: payload.platform,
+        count: payload.count,
+      }
       const { data } = await api.post<ApiResponse<GenerateCaptionResponse>>(
         '/api/captions/generate',
-        payload,
+        body,
       )
       return data.data
     },

--- a/frontend/store/captionStore.ts
+++ b/frontend/store/captionStore.ts
@@ -2,20 +2,21 @@ import { create } from 'zustand'
 import type { Caption, Language, Tone, Platform } from '@/types'
 
 interface CaptionState {
-  // Form values
   topic: string
+  imageBase64: string
+  imageMediaType: string
   language: Language
   tone: Tone
   platform: Platform
   count: number
 
-  // Results
   captions: Caption[]
   personalizationUsed: boolean
   confidenceScore: number
 
-  // Actions
   setTopic: (topic: string) => void
+  setImage: (base64: string, mediaType: string) => void
+  clearImage: () => void
   setLanguage: (language: Language) => void
   setTone: (tone: Tone) => void
   setPlatform: (platform: Platform) => void
@@ -27,6 +28,8 @@ interface CaptionState {
 
 const defaults = {
   topic: '',
+  imageBase64: '',
+  imageMediaType: '',
   language: 'english' as Language,
   tone: 'casual' as Tone,
   platform: 'instagram' as Platform,
@@ -40,6 +43,8 @@ export const useCaptionStore = create<CaptionState>((set) => ({
   ...defaults,
 
   setTopic: (topic) => set({ topic }),
+  setImage: (imageBase64, imageMediaType) => set({ imageBase64, imageMediaType }),
+  clearImage: () => set({ imageBase64: '', imageMediaType: '' }),
   setLanguage: (language) => set({ language }),
   setTone: (tone) => set({ tone }),
   setPlatform: (platform) => set({ platform }),

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -60,7 +60,9 @@ export interface UserProfile {
 }
 
 export interface GenerateCaptionRequest {
-  topic: string
+  topic?: string
+  imageBase64?: string
+  imageMediaType?: string
   language: Language
   tone: Tone
   platform: Platform


### PR DESCRIPTION
Closes #91

## What's new
Users can now upload a photo on the Generate page and Claude will analyse what's in it to write captions — no topic required.

## How it works
1. User uploads a JPEG/PNG/WebP (≤ 4 MB) — a drag-and-drop zone appears in the form
2. The image is base64-encoded client-side and sent with the generate request
3. Backend passes it to Claude as a vision content block alongside the usual system prompt
4. Captions are generated from the image, optionally enhanced by any extra context the user types
5. Topic stored in DB falls back to '📷 Photo' when no text topic is provided

## Changes
- **Backend**: \GenerateCaptionRequest\ accepts \image_base64\ + \image_media_type\ (topic optional); \ClaudeService\ builds a vision message when image present
- **Frontend**: image upload UI with preview + remove button; \captionStore\ adds \setImage\/\clearImage\; hook maps camelCase → snake_case before API call